### PR TITLE
Bug: if HOME env is not set, like in SM Studio, os.environ.get return…

### DIFF
--- a/src/famly/util/dataset.py
+++ b/src/famly/util/dataset.py
@@ -20,7 +20,7 @@ def cache_dir(*paths) -> str:
     """
     j = os.path.join
     path = j(
-        os.environ.get("XDG_CACHE_HOME", j(os.environ.get("HOME"), ".cache")),  # type: ignore
+        os.environ.get("XDG_CACHE_HOME", j(os.environ.get("HOME", ""), ".cache")),  # type: ignore
         "famly",
         "datasets",
     )


### PR DESCRIPTION
*Issue #, if available:*
Bug: if HOME env is not set, like in SM Studio, os.environ.get returns None and os.path.join will crash

*Description of changes:*
Add an empty str of "" as the default when get HOME environment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
