### PR TITLE
Remove duplicate code for CDD and DPL

### DIFF
--- a/src/famly/bias/metrics/__init__.py
+++ b/src/famly/bias/metrics/__init__.py
@@ -14,7 +14,7 @@ __all__ = registry.all_metrics()
 
 
 METRICS_ARITY_DYADIC = set([CI])
-METRICS_ARITY_TETRADIC = set([DPL])
+METRICS_ARITY_TETRADIC = set([DPTL])
 METRICS_ARITY_HEXADIC = set([AD, DPPL, DI, DCO, RD, DLR, AD, TE, FT])
 
 

--- a/src/famly/bias/metrics/common.py
+++ b/src/famly/bias/metrics/common.py
@@ -8,11 +8,11 @@ def require(condition: bool, message: str) -> None:
         raise RuntimeError(message)
 
 
-def DPL(facet: pd.Series, label: pd.Series, positive_label: Any) -> float:
+def DPL(x: pd.Series, facet: pd.Series, label: pd.Series, positive_label: Any) -> float:
     positive_label_index = label == positive_label
     facet = facet.astype(bool)
-    na = len(facet[~facet])
-    nd = len(facet[facet])
+    na = len(x[~facet])
+    nd = len(x[facet])
     na_pos = len(label[~facet & positive_label_index])
     nd_pos = len(label[facet & positive_label_index])
     if na == 0:
@@ -25,8 +25,9 @@ def DPL(facet: pd.Series, label: pd.Series, positive_label: Any) -> float:
     return dpl
 
 
-def CDD(facet: pd.Series, label: pd.Series, group_variable: pd.Series) -> float:
+def CDD(x: pd.Series, facet: pd.Series, label: pd.Series, group_variable: pd.Series) -> float:
     """
+    :param x: input feature
     :param facet: boolean column indicating sensitive group
     :param label: boolean column indicating positive labels
     :param group_variable: categorical column indicating subgroups each point belongs to
@@ -37,11 +38,11 @@ def CDD(facet: pd.Series, label: pd.Series, group_variable: pd.Series) -> float:
     facet = facet.astype(bool)
 
     # Global demographic disparity (DD)]
-    denomA = len(facet[label])
+    denomA = len(x[label])
 
     if denomA == 0:
         raise ValueError("CDD: No positive labels in set")
-    denomD = len(facet[~label])
+    denomD = len(x[~label])
 
     if denomD == 0:
         raise ValueError("CDD: No negative labels in set")
@@ -52,10 +53,10 @@ def CDD(facet: pd.Series, label: pd.Series, group_variable: pd.Series) -> float:
     for subgroup_variable in unique_groups:
         counts = np.append(counts, len(group_variable[group_variable == subgroup_variable]))
         numA = len(label[label & facet & (group_variable == subgroup_variable)])
-        denomA = len(facet[label & (group_variable == subgroup_variable)])
+        denomA = len(x[label & (group_variable == subgroup_variable)])
         A = numA / denomA if denomA != 0 else 0
         numD = len(label[(~label) & facet & (group_variable == subgroup_variable)])
-        denomD = len(facet[(~label) & (group_variable == subgroup_variable)])
+        denomD = len(x[(~label) & (group_variable == subgroup_variable)])
         D = numD / denomD if denomD != 0 else 0
         CDD = np.append(CDD, D - A)
 

--- a/src/famly/bias/metrics/posttraining.py
+++ b/src/famly/bias/metrics/posttraining.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 
 @registry.posttraining
-def DPPL(x: pd.Series, facet: pd.Series, predicted_labels: pd.Series, positive_predicted_label: Any) -> float:
+def DPPL(x: pd.Series, facet: pd.Series, predicted_label: pd.Series, positive_predicted_label: Any) -> float:
     r"""
     Difference in positive proportions in predicted labels.
 
@@ -24,15 +24,15 @@ def DPPL(x: pd.Series, facet: pd.Series, predicted_labels: pd.Series, positive_p
 
     :param x: input feature
     :param facet: boolean column indicating sensitive group
-    :param labels: boolean column indicating true values of target column
-    :param predicted_labels: boolean column indicating predictions made by model
+    :param predicted_label: boolean column indicating predictions made by model
+    :param positive_predicted_label: consider this label value as the positive value in predicted label, default is 1.
     :return: Returns Difference in Positive Proportions, based on predictions rather than true labels
     """
-    return common.DPL(facet, predicted_labels, positive_predicted_label)
+    return common.DPL(x, facet, predicted_label, positive_predicted_label)
 
 
 @registry.posttraining
-def DI(x: pd.Series, facet: pd.Series, labels: pd.Series, predicted_labels: pd.Series) -> float:
+def DI(x: pd.Series, facet: pd.Series, predicted_labels: pd.Series) -> float:
     r"""
     Disparate Impact
 
@@ -44,20 +44,18 @@ def DI(x: pd.Series, facet: pd.Series, labels: pd.Series, predicted_labels: pd.S
 
     :param x: input feature
     :param facet: boolean column indicating sensitive group
-    :param labels: boolean column indicating true values of target column
     :param predicted_labels: boolean column indicating predictions made by model
     :return: Returns disparate impact, the ratio between positive proportions, based on predicted labels
     """
     predicted_labels = predicted_labels.astype(bool)
-    labels = labels.astype(bool)
     facet = facet.astype(bool)
     na1hat = len(predicted_labels[predicted_labels & (~facet)])
-    na = len(facet[~facet])
+    na = len(x[~facet])
     if na == 0:
         raise ValueError("DI: Negated facet set is empty")
     qa = na1hat / na
     nd1hat = len(predicted_labels[predicted_labels & facet])
-    nd = len(facet[facet])
+    nd = len(x[facet])
     if nd == 0:
         raise ValueError("DI: Facet set is empty")
     qd = nd1hat / nd
@@ -79,9 +77,9 @@ def DCO(x: pd.Series, facet: pd.Series, labels: pd.Series, predicted_labels: pd.
     labels = labels.astype(bool)
     facet = facet.astype(bool)
 
-    if len(facet[facet]) == 0:
+    if len(x[facet]) == 0:
         raise ValueError("DCO: Facet set is empty")
-    if len(facet[~facet]) == 0:
+    if len(x[~facet]) == 0:
         raise ValueError("DCO: Negated Facet set is empty")
 
     TN_a = len(labels[(~labels) & (~predicted_labels) & (~facet)])
@@ -138,9 +136,9 @@ def RD(x: pd.Series, facet: pd.Series, labels: pd.Series, predicted_labels: pd.S
     labels = labels.astype(bool)
     facet = facet.astype(bool)
 
-    if len(facet[facet]) == 0:
+    if len(x[facet]) == 0:
         raise ValueError("RD: Facet set is empty")
-    if len(facet[~facet]) == 0:
+    if len(x[~facet]) == 0:
         raise ValueError("RD: Negated Facet set is empty")
 
     TP_a = len(labels[(labels) & (predicted_labels) & (~facet)])
@@ -173,9 +171,9 @@ def DLR(x: pd.Series, facet: pd.Series, labels: pd.Series, predicted_labels: pd.
     labels = labels.astype(bool)
     facet = facet.astype(bool)
 
-    if len(facet[facet]) == 0:
+    if len(x[facet]) == 0:
         raise ValueError("DLR: Facet set is empty")
-    if len(facet[~facet]) == 0:
+    if len(x[~facet]) == 0:
         raise ValueError("DLR: Negated Facet set is empty")
 
     TP_a = len(labels[(labels) & (predicted_labels) & (~facet)])
@@ -223,7 +221,7 @@ def DLR(x: pd.Series, facet: pd.Series, labels: pd.Series, predicted_labels: pd.
 def AD(
     x: pd.Series,
     facet: pd.Series,
-    label: pd.Series,
+    true_label: pd.Series,
     positive_label: Any,
     predicted_label: pd.Series,
     positive_predicted_label: Any,
@@ -240,7 +238,7 @@ def AD(
     :return: Accuracy Difference between advantaged and disadvantaged classes
     """
     predicted_label = predicted_label.astype(bool)
-    label = label.astype(bool)
+    true_label = true_label.astype(bool)
     facet = facet.astype(bool)
 
     if len(x[facet]) == 0:
@@ -248,29 +246,29 @@ def AD(
     if len(x[~facet]) == 0:
         raise ValueError("AD: Negated Facet set is empty")
 
-    label_idx = label == positive_label
+    label_idx = true_label == positive_label
     pred_label_idx = predicted_label == positive_predicted_label
 
     idx_tp_a = label_idx & pred_label_idx & ~facet
-    TP_a = len(label[idx_tp_a])
+    TP_a = len(true_label[idx_tp_a])
     idx_fp_a = ~label_idx & pred_label_idx & ~facet
-    FP_a = len(label[idx_fp_a])
+    FP_a = len(true_label[idx_fp_a])
     idx_fn_a = label_idx & ~pred_label_idx & ~facet
-    FN_a = len(label[idx_fn_a])
+    FN_a = len(true_label[idx_fn_a])
     idx_tn_a = ~label_idx & ~pred_label_idx & ~facet
-    TN_a = len(label[idx_tn_a])
+    TN_a = len(true_label[idx_tn_a])
 
     total_a = TP_a + TN_a + FP_a + FN_a
     acc_a = (TP_a + TN_a) / total_a if total_a != 0 else INFINITY
 
     idx_tp_d = label_idx & pred_label_idx & facet
-    TP_d = len(label[idx_tp_d])
+    TP_d = len(true_label[idx_tp_d])
     idx_fp_d = ~label_idx & pred_label_idx & facet
-    FP_d = len(label[idx_fp_d])
+    FP_d = len(true_label[idx_fp_d])
     idx_fn_d = label_idx & ~pred_label_idx & facet
-    FN_d = len(label[idx_fn_d])
+    FN_d = len(true_label[idx_fn_d])
     idx_tn_d = ~label_idx & ~pred_label_idx & facet
-    TN_d = len(label[idx_tn_d])
+    TN_d = len(true_label[idx_tn_d])
 
     total_d = TP_d + TN_d + FP_d + FN_d
     acc_d = (TP_d + TN_d) / total_d if total_d != 0 else INFINITY
@@ -281,10 +279,22 @@ def AD(
     return ad
 
 
-# FIXME, CDD needs to be looked into
+# FIXME, CDDPL needs to be looked into
 # @registry.posttraining
 def CDDPL(x: pd.Series, facet: pd.Series, predicted_labels: pd.Series, group_variable: pd.Series) -> float:
-    return common.CDD(facet, predicted_labels, group_variable)
+    """
+    Conditional Demographic Disparity in true labels
+    .. math::
+        CDD = \frac{1}{n}\sum_i n_i * DD_i \\\quad\:where \: DD_i = \frac{Number\:of\:rejected\:applicants\:protected\:facet}{Total\:number\:of\:rejected\:applicants} -
+        \frac{Number\:of\:accepted\:applicants\:protected\:facet}{Total\:number\:of\:accepted\:applicants} \\for\:each\:group\:variable\: i
+
+    :param x: input feature
+    :param facet: boolean column indicating sensitive group
+    :param true_label: boolean column indicating positive labels
+    :param group_variable: categorical column indicating subgroups each point belongs to
+    :return: the weighted average of demographic disparity on all subgroups
+    """
+    return common.CDD(x, facet, predicted_labels, group_variable)
 
 
 @registry.posttraining
@@ -301,9 +311,9 @@ def TE(x: pd.Series, facet: pd.Series, labels: pd.Series, predicted_labels: pd.S
     labels = labels.astype(bool)
     facet = facet.astype(bool)
 
-    if len(facet[facet]) == 0:
+    if len(x[facet]) == 0:
         raise ValueError("TE: Facet set is empty")
-    if len(facet[~facet]) == 0:
+    if len(x[~facet]) == 0:
         raise ValueError("TE: Negated Facet set is empty")
 
     FP_a = len(labels[(~labels) & (predicted_labels) & (~facet)])

--- a/src/famly/bias/metrics/pretraining.py
+++ b/src/famly/bias/metrics/pretraining.py
@@ -45,16 +45,16 @@ def CI(x: pd.Series, facet: pd.Series) -> float:
 
 
 @registry.pretraining
-def DPL(x: pd.Series, facet: pd.Series, label: pd.Series, positive_label: Any) -> float:
+def DPTL(x: pd.Series, facet: pd.Series, true_label: pd.Series, positive_label: Any) -> float:
     """
-    Difference in positive proportions in labels
+    Difference in positive proportions in true labels
     :param x: input feature
     :param facet: boolean column indicating sensitive group
-    :param label: pandas series of labels (binary, multicategory, or continuous)
-    :param positive_label_index: consider this label value as the positive value, default is 1.
+    :param true_label: pandas series of labels (binary, multicategory, or continuous)
+    :param positive_label: consider this label value as the positive value, default is 1.
     :return: a float in the interval [-1, +1] indicating bias in the labels.
     """
-    return common.DPL(facet, label, positive_label)
+    return common.DPL(x, facet, true_label, positive_label)
 
 
 @registry.pretraining
@@ -158,14 +158,19 @@ def KS(x: pd.Series, facet: pd.Series) -> float:
     return LP(x, facet, 1)
 
 
-# FIXME, CDD needs to be looked into
+# FIXME, CDDTL needs to be looked into
 # @registry.pretraining
-def CDDL(x: pd.Series, facet: pd.Series, positive_label_index: pd.Series, group_variable: pd.Series) -> float:
+def CDDTL(x: pd.Series, facet: pd.Series, true_label: pd.Series, group_variable: pd.Series) -> float:
     """
+    Conditional Demographic Disparity in true labels
+    .. math::
+        CDD = \frac{1}{n}\sum_i n_i * DD_i \\\quad\:where \: DD_i = \frac{Number\:of\:rejected\:applicants\:protected\:facet}{Total\:number\:of\:rejected\:applicants} -
+        \frac{Number\:of\:rejected\:applicants\:protected\:facet}{Total\:number\:of\:rejected\:applicants} \\\quad\:\quad\:\quad\:\quad\:\quad\:\quad\:for\:each\:group\:variable\: i
+
     :param x: input feature
     :param facet: boolean column indicating sensitive group
-    :param positive_label_index: boolean column indicating positive labels
+    :param true_label: boolean column indicating positive labels
     :param group_variable: categorical column indicating subgroups each point belongs to
     :return: the weighted average of demographic disparity on all subgroups
     """
-    return common.CDD(facet, positive_label_index, group_variable)
+    return common.CDD(x, facet, true_label, group_variable)

--- a/tests/unit/bias/metrics/test_metrics.py
+++ b/tests/unit/bias/metrics/test_metrics.py
@@ -1,4 +1,4 @@
-from famly.bias.metrics import AD, CI, DCO, DI, DLR, DPL, FT, JS, KL, LP, RD, TE
+from famly.bias.metrics import AD, CI, DCO, DI, DLR, DPTL, FT, JS, KL, LP, RD, TE
 from famly.bias.metrics import metric_one_vs_all
 from famly.bias.metrics.constants import INFINITY
 from pytest import approx
@@ -174,7 +174,7 @@ def test_CI():
 
 def test_DPL():
     df = pd.DataFrame({"x": ["a", "a", "b", "b"], "y": [1, 1, 0, 1]})
-    res = metric_one_vs_all(DPL, df["x"], df["y"], 1)
+    res = metric_one_vs_all(DPTL, df["x"], df["y"], 1)
     assert res["a"] == -0.5
     assert res["b"] == 0.5
     return
@@ -250,7 +250,7 @@ def test_LP():
 #    positive_label_index = pd.Series([0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0])
 #    group_variable = pd.Series([1, 0, 2, 2, 1, 1, 2, 1, 1, 2, 0, 1, 2, 0, 1, 1, 1, 2, 0, 1, 0, 0, 1, 1])
 #
-#    response = metric_one_vs_all(CDD, x, positive_label_index=positive_label_index, group_variable=group_variable)
+#    response = metric_one_vs_all(CDDTL, x, positive_label_index=positive_label_index, group_variable=group_variable)
 #    assert response["F"] == approx(0.3982142857)
 #    assert response["M"] == approx(-0.3982142857)
 #
@@ -281,16 +281,16 @@ def test_DI():
     facet = dfB[0] == "F"
     predicted = pd.Series([1, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0])
     labels = pd.Series([0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 0])
-    assert DI(dfB[0], facet, labels, predicted) == approx(1.4285714285)
+    assert DI(dfB[0], facet, predicted) == approx(1.4285714285)
 
     facet = dfB[0] == "M"
-    assert DI(dfB[0], facet, labels, predicted) == approx(0.700000000)
+    assert DI(dfB[0], facet, predicted) == approx(0.700000000)
 
     pred_labels_zero_for_M = pd.Series([0, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 1])
-    assert DI(dfB[0], dfB[0] == "F", labels, pred_labels_zero_for_M) == INFINITY
+    assert DI(dfB[0], dfB[0] == "F", pred_labels_zero_for_M) == INFINITY
     # Check empty facet selection
     with pytest.raises(ValueError) as e:
-        DI(dfB[0], dfB[0] == None, labels, predicted)
+        DI(dfB[0], dfB[0] == None, predicted)
     assert str(e.value) == "DI: Facet set is empty"
 
     # Check empty facet selection
@@ -298,7 +298,7 @@ def test_DI():
         x = Series(["A", "A"])
         labels = Series([0, 1])
         pred = Series([0, 1])
-        DI(x, x == "A", labels, pred)
+        DI(x, x == "A", pred)
     assert str(e.value) == "DI: Negated facet set is empty"
 
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/famly/issues/28

*Description of changes:*
Removes duplicate code between pretraining and posttraining for DPL and CDD metrics. 

There are a couple of concerns I would like to raise here:

1. I feel there is some confusion in naming metrics and labels. For example, 
Difference in positive proportions in true label - DPL
Difference in positive proportions in prediction label - DPPL
Conditional Demographic Disparity in true label - CDD
Conditional Demographic Disparity in predicted label - CDDPL?

2. Since we are planning to open-source this package, I feel that having the same metric with different input may feel weird or unintuitive to the normal user. 

3. Throughout the package, we are using label to mean label to mean both true label, and a generic label which can be confusing. I think it will be simpler if we switch to calling it true_label and label separately. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
