### PR TITLE
Fix ModuleNotFoundError: No module named jupyter_contrib_nbextensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ EXTRAS_REQUIRE = {
         "coverage",
         "nbconvert",
         "jupyter",
+        "jupyter_contrib_nbextensions",
         "seaborn",
         "mypy",
         "lxml",


### PR DESCRIPTION
# Summary

"./devtool all" failed with above error in a new virtualenv, after "./devtool install_deps_dev".

This commit resolves the issue by adding the missing package as a test dependency.

# Testing Done

Setup a new virtualenv

```
$ mkvirtualenv famly
$ ./devtool install_deps_dev
```

## Unit Test

Passed.

```
$ ./devtool all
CD -> /Users/xgchen/Desktop/workspace/famly

Lint checks
===========

1. pre-commit hooks
===================
Check Yaml...............................................................Passed
- hook id: check-yaml
- duration: 0.17s
Fix End of Files.........................................................Passed
- hook id: end-of-file-fixer
- duration: 0.2s
Trim Trailing Whitespace.................................................Passed
- hook id: trailing-whitespace
- duration: 0.15s
Detect AWS Credentials...................................................Passed
- hook id: detect-aws-credentials
- duration: 0.17s
autoflake................................................................Passed
- hook id: autoflake
- duration: 0.49s
black....................................................................Passed
- hook id: black
- duration: 1.06s

All done! ✨ 🍰 ✨
20 files left unchanged.


2. Flake8
=========
0

3. Mypy
=======
Generated HTML report (via XSLT): /Users/xgchen/Desktop/workspace/famly/reports/index.html
Success: no issues found in 12 source files

Lint: SUCCESS
run_examples.py: 2020-08-28 23:47:53,149Z INFO Running example notebooks
run_examples.py: 2020-08-28 23:47:53,150Z INFO Running notebook: examples/Bias_metrics_usage.ipynb
[NbConvertApp] WARNING | Config option `template_path` not recognized by `NotebookExporter`.
[NbConvertApp] Converting notebook examples/Bias_metrics_usage.ipynb to notebook
[NbConvertApp] Executing notebook with kernel: python3
run_examples.py: 2020-08-28 23:48:01,905Z INFO Running notebook: examples/Bias_metrics_usage_marketing.ipynb
[NbConvertApp] WARNING | Config option `template_path` not recognized by `NotebookExporter`.
[NbConvertApp] Converting notebook examples/Bias_metrics_usage_marketing.ipynb to notebook
[NbConvertApp] Executing notebook with kernel: python3
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /Users/xgchen/Desktop/workspace/famly
plugins: pspec-0.0.4
collected 26 items

tests/unit/test_util.py
util
 ✓ pdf
 ✓ pdfs aligned
                                                                                                                                                                                                   [  7%]
tests/unit/bias/test_report.py
report
 ✓ report category data
 ✓ report continuous data
 ✓ Test bias metrics for multiple label values
 ✓ test the list of callable metric functions to be run
 ✓ Test that bias report is generated in for partial metrics when errors occur to compute some metrics
 ✓ Test the list of callable metrics have descriptions present
 ✓ Tests whether exception is raised when predicted label values are differnt from positive label values
 ✓ problem type
                                                                                                                                                                                                   [ 38%]
tests/unit/bias/metrics/test_metrics.py
metrics
 ✓ CI
 ✓ DPL
 ✓ KL
 ✓ JS
 ✓ LP
 ✓ DI
 ✓ DCA
 ✓ DCR
 ✓ RD
 ✓ DRR
 ✓ AD
 ✓ DAR
 ✓ TE
 ✓ FT
                                                                                                                                                                                                   [ 92%]
tests/unit/bias/metrics/test_registry.py
registry
 ✓ valid registration
 ✓ invalid registration
                                                                                                                                                                                                   [100%]

=========================================================================================== 26 passed in 3.49s ===========================================================================================
Name                                     Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------------------
src/famly/__init__.py                        0      0      0      0   100%
src/famly/bias/__init__.py                   2      0      0      0   100%
src/famly/bias/metrics/__init__.py          18      0      4      0   100%
src/famly/bias/metrics/common.py           144     20     60     20    79%   23-24, 33->34, 34, 45->46, 46, 47->48, 48, 74->75, 75, 78->79, 79, 119->120, 120, 121->122, 122, 123->128, 126->128, 151->152, 152, 153->154, 154, 166->169, 169, 171->174, 174, 176->179, 179, 189->190, 190, 191->192, 192, 217->218, 218, 219->220, 220, 232->235, 235, 255->256, 256
src/famly/bias/metrics/constants.py          2      0      0      0   100%
src/famly/bias/metrics/posttraining.py     145     11     38     11    88%   134->135, 135, 136->137, 137, 151->152, 152, 217->218, 218, 219->220, 220, 247->248, 248, 295->296, 296, 297->298, 298, 310->311, 311, 342->343, 343, 344->345, 345
src/famly/bias/metrics/pretraining.py       65      2     10      2    95%   38->39, 39, 40->41, 41
src/famly/bias/metrics/registry.py          21      0     10      0   100%
src/famly/bias/report.py                   181     19     58     13    85%   106->108, 108, 116-117, 128->129, 129, 142->143, 143, 147->149, 171->174, 174, 176->177, 177, 198->202, 202, 215-218, 259->279, 275-279, 337->341, 341->342, 342, 344->348, 348->349, 349, 417->443, 443
src/famly/util/__init__.py                  41     12     28      0    71%   12-16, 26-37
------------------------------------------------------------------------------------
TOTAL                                      619     64    208     46    85%
Running Sphinx v3.2.1
loading pickled environment... failed
failed: No such config value: c_allow_pre_v3
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 6 source files that are out of date
updating environment: [new config] 6 added, 0 changed, 0 removed
reading sources... [100%] modules
looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/xgchen/Desktop/workspace/famly/docs/source/modules.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] modules
generating indices...  genindex py-modindexdone
writing additional pages...  searchdone
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 1 warning.

The HTML pages are in build/html.
```

## Actions

Passed. 

https://github.com/xgchena/famly/actions/runs/229437522

---- 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
