### PR TITLE
Update FT metric, drop facet and label colums from dataset

### DIFF
--- a/src/famly/bias/report.py
+++ b/src/famly/bias/report.py
@@ -101,7 +101,6 @@ def problem_type(labels: pd.Series) -> ProblemType:
     """
     # TODO: add other problem types
     labels = labels.dropna()
-    n_rows = len(labels)
     n_unique = labels.unique().size
     if n_unique == 2:
         return ProblemType.BINARY
@@ -363,10 +362,13 @@ def bias_report(
         raise ValueError("predicted_label_column has to be provided for Post training metrics")
 
     data_series: pd.Series = df[facet_column.name]
+    df = df.drop(facet_column.name, 1)
     label_series: pd.Series = label_column.data
     positive_label_index, label_values = _positive_label_index(
         data=label_series, positive_values=label_column.positive_label_values
     )
+    if label_column.name in df.columns:
+        df = df.drop(label_column.name, 1)
 
     metrics_to_run = []
     if predicted_label_column and stage_type == StageType.POST_TRAINING:
@@ -382,6 +384,8 @@ def bias_report(
             label_data=label_series,
             positive_label_values=label_column.positive_label_values,
         )
+        if predicted_label_column.name in df.columns:
+            df = df.drop(predicted_label_column.name, 1)
     else:
         positive_predicted_label_index = [None]
         predicted_label_series = None

--- a/tests/unit/bias/test_report.py
+++ b/tests/unit/bias/test_report.py
@@ -11,22 +11,15 @@ from famly.bias.report import (
 )
 from famly.bias.metrics import PRETRAINING_METRICS, POSTTRAINING_METRICS, CI, DPL, KL, KS, DPPL, DI, DCA, DCR, RD
 from famly.bias.metrics import common
-from typing import List, Any
-
-
-def dataframe(data: List[List[Any]]):
-    df = pd.DataFrame(data, columns=["x", "y", "z", "yhat"])
-    return df
-
-
-df_cat = dataframe([["a", 1, 1, 1], ["b", 1, 1, 0], ["b", 0, 1, 0], ["b", 0, 0, 1]])
-df_cont = dataframe([[1, 1, 1, 1], [2, 1, 1, 0], [3, 0, 0, 0], [2, 0, 1, 1], [0, 0, 1, 1]])
 
 
 def test_report_category_data():
     # test the bias_report function on the category data
     #
     # pre training bias metrics
+    df_cat = pd.DataFrame(
+        [["a", 1, 1, 1], ["b", 1, 1, 0], ["b", 0, 1, 0], ["b", 0, 0, 1]], columns=["x", "y", "z", "yhat"]
+    )
     pretraining_report = bias_report(
         df_cat,
         FacetColumn("x"),
@@ -131,6 +124,36 @@ def test_report_continuous_data():
     #   test the bias_report function on the category data
     #
     # pre training bias metrics
+    df_cont = pd.DataFrame(
+        [
+            [0, 0, 0, 0, True, 1, 1, 1],
+            [3, 0, 0, 0, True, 0, 1, 1],
+            [3, 0, 1, 0, True, 0, 1, 1],
+            [0, 0, 0, 0, False, 1, 1, 0],
+            [4, 0, 0, 1, True, 0, 1, 1],
+            [0, 0, 1, 0, True, 1, 1, 1],
+            [3, 0, 0, 0, True, 1, 1, 1],
+            [3, 1, 0, 0, True, 1, 1, 1],
+            [0, 0, 1, 0, True, 1, 1, 1],
+            [3, 0, 1, 1, True, 1, 0, 1],
+            [4, 0, 0, 0, True, 1, 0, 1],
+            [3, 0, 1, 0, True, 1, 1, 1],
+            [3, 0, 0, 0, False, 1, 1, 0],
+            [0, 0, 0, 0, True, 1, 1, 1],
+            [0, 0, 1, 0, True, 0, 1, 1],
+            [0, 0, 1, 0, True, 1, 1, 1],
+            [0, 1, 0, 1, False, 0, 1, 0],
+            [3, 0, 0, 0, False, 1, 1, 0],
+            [0, 0, 1, 0, False, 1, 1, 1],
+            [3, 0, 0, 0, True, 1, 0, 1],
+            [3, 0, 1, 0, False, 1, 1, 0],
+            [0, 1, 0, 0, False, 1, 1, 0],
+            [3, 0, 1, 0, True, 0, 1, 1],
+            [0, 0, 0, 1, True, 1, 0, 1],
+        ],
+        columns=["x", "y", "z", "a", "b", "c", "d", "yhat"],
+    )
+
     pretraining_report = bias_report(
         df_cont,
         FacetColumn("x", [2]),
@@ -144,18 +167,27 @@ def test_report_continuous_data():
     result = [
         {
             "metrics": [
-                {"description": "Class Imbalance (CI)", "name": "CI", "value": 0.6},
-                {"description": "Difference in Positive Proportions in Labels " "(DPL)", "name": "DPL", "value": 0.5},
-                {"description": "Kullback-Liebler Divergence (KL)", "name": "KL", "value": -0.34657359027997264},
-                {"description": "Jensen-Shannon Divergence (JS)", "name": "JS", "value": 0.20983242268450672},
-                {"description": "L-p Norm (LP)", "name": "LP", "value": 0.5},
-                {"description": "Total Variation Distance (TVD)", "name": "TVD", "value": 0.25},
-                {"description": "Kolmogorov-Smirnov Distance (KS)", "name": "KS", "value": 0.5},
-                {"description": "Conditional Demographic Disparity in Labels " "(CDDL)", "name": "CDDL", "value": 0.2},
+                {"description": "Class Imbalance (CI)", "name": "CI", "value": -0.08333333333333333},
+                {
+                    "description": "Difference in Positive Proportions in Labels " "(DPL)",
+                    "name": "DPL",
+                    "value": 0.1048951048951049,
+                },
+                {"description": "Kullback-Liebler Divergence (KL)", "name": "KL", "value": 0.057704603668062765},
+                {"description": "Jensen-Shannon Divergence (JS)", "name": "JS", "value": 0.012610670256663018},
+                {"description": "L-p Norm (LP)", "name": "LP", "value": 0.14834407996920576},
+                {"description": "Total Variation Distance (TVD)", "name": "TVD", "value": 0.1048951048951049},
+                {"description": "Kolmogorov-Smirnov Distance (KS)", "name": "KS", "value": 0.2097902097902098},
+                {
+                    "description": "Conditional Demographic Disparity in Labels " "(CDDL)",
+                    "name": "CDDL",
+                    "value": 0.3851010101010101,
+                },
             ],
-            "value_or_threshold": "(2, 3]",
+            "value_or_threshold": "(2, 4]",
         }
     ]
+
     assert pretraining_report == result
 
     posttraining_report = bias_report(
@@ -174,24 +206,24 @@ def test_report_continuous_data():
                 {
                     "description": '"Difference in Positive Proportions in ' 'Predicted Labels (DPPL)")',
                     "name": "DPPL",
-                    "value": 0.75,
+                    "value": -0.04195804195804198,
                 },
-                {"description": "Disparate Impact (DI)", "name": "DI", "value": 0.0},
-                {"description": "Difference in Conditional Acceptance (DCA)", "name": "DCA", "value": "-Infinity"},
-                {"description": "Difference in Conditional Rejection (DCR)", "name": "DCR", "value": -1.0},
-                {"description": "Recall Difference (RD)", "name": "RD", "value": "-Infinity"},
-                {"description": "Difference in Acceptance Rates (DAR)", "name": "DAR", "value": "-Infinity"},
-                {"description": "Difference in Rejection Rates (DRR)", "name": "DRR", "value": 1.0},
-                {"description": "Accuracy Difference (AD)", "name": "AD", "value": -0.75},
+                {"description": "Disparate Impact (DI)", "name": "DI", "value": 1.0576923076923077},
+                {"description": "Difference in Conditional Acceptance (DCA)", "name": "DCA", "value": 0.15},
+                {"description": "Difference in Conditional Rejection (DCR)", "name": "DCR", "value": 1.0},
+                {"description": "Recall Difference (RD)", "name": "RD", "value": -1.0},
+                {"description": "Difference in Acceptance Rates (DAR)", "name": "DAR", "value": -0.1},
+                {"description": "Difference in Rejection Rates (DRR)", "name": "DRR", "value": 0.6666666666666667},
+                {"description": "Accuracy Difference (AD)", "name": "AD", "value": -0.2167832167832168},
                 {
                     "description": "Conditional Demographic Disparity in Predicted " "Labels (CDDPL)",
                     "name": "CDDPL",
-                    "value": 0.2,
+                    "value": 0.07592592592592595,
                 },
-                {"description": "Treatment Equality (TE)", "name": "TE", "value": "Infinity"},
-                {"description": "Flip Test (FT)", "name": "FT", "value": 0.0},
+                {"description": "Treatment Equality (TE)", "name": "TE", "value": -0.25},
+                {"description": "Flip Test (FT)", "name": "FT", "value": -0.23076923076923078},
             ],
-            "value_or_threshold": "(2, 3]",
+            "value_or_threshold": "(2, 4]",
         }
     ]
     assert posttraining_report == expected_result_1
@@ -201,7 +233,10 @@ def test_label_values():
     """
     Test bias metrics for multiple label values
     """
-    df = dataframe([["a", "p", 1, "p"], ["b", "q", 1, "p"], ["b", "r", 1, "q"], ["c", "p", 0, "p"], ["c", "q", 0, "p"]])
+    df = pd.DataFrame(
+        [["a", "p", 1, "p"], ["b", "q", 1, "p"], ["b", "r", 1, "q"], ["c", "p", 0, "p"], ["c", "q", 0, "p"]],
+        columns=["x", "y", "z", "yhat"],
+    )
     # when  explicit label values are given for categorical data
     # Pre training bias metrics
     pretraining_report = bias_report(
@@ -324,14 +359,16 @@ def test_partial_bias_report():
     """
     Test that bias report is generated in for partial metrics when errors occur to compute some metrics
     """
-    df = dataframe([[1, 1, 1, 1], [2, 1, 1, 0], [3, 0, 0, 0], [2, 0, 1, 1], [0, 0, 1, 1]])
+    df = pd.DataFrame(
+        [[1, 1, 1, 1], [2, 1, 1, 0], [3, 0, 0, 0], [2, 0, 1, 1], [0, 0, 1, 1]], columns=["x", "y", "z", "yhat"]
+    )
     # pre training bias metrics
     pretraining_report = bias_report(
         df,
         FacetColumn("x", [2]),
-        LabelColumn("y", df_cont["y"], [0]),
+        LabelColumn("y", df["y"], [0]),
         StageType.PRE_TRAINING,
-        LabelColumn("yhat", df_cont["yhat"]),
+        LabelColumn("yhat", df["yhat"]),
         metrics=["CI", "CDDL", "DPL", "KL"],
     )
     assert isinstance(pretraining_report, list)
@@ -357,9 +394,9 @@ def test_partial_bias_report():
     posttraining_report = bias_report(
         df,
         FacetColumn("x", [2]),
-        LabelColumn("y", df_cont["y"], [0]),
+        LabelColumn("y", df["y"], [0]),
         StageType.POST_TRAINING,
-        LabelColumn("yhat", df_cont["yhat"]),
+        LabelColumn("yhat", df["yhat"]),
         metrics=["AD", "CDDPL", "DCA", "DI", "DPPL", "FT"],
     )
     assert isinstance(posttraining_report, list)
@@ -380,7 +417,7 @@ def test_partial_bias_report():
                     "name": "CDDPL",
                     "value": None,
                 },
-                {"description": "Flip Test (FT)", "name": "FT", "value": 0.0},
+                {"description": "Flip Test (FT)", "name": "FT", "value": -1.0},
             ],
             "value_or_threshold": "(2, 3]",
         }
@@ -436,7 +473,10 @@ def test_predicted_label_values():
     """
     Tests whether exception is raised when predicted label values are differnt from positive label values
     """
-    df = dataframe([["a", "p", 1, "p"], ["b", "q", 1, "p"], ["b", "r", 1, "q"], ["c", "p", 0, "p"], ["c", "q", 0, "p"]])
+    df = pd.DataFrame(
+        [["a", "p", 1, "p"], ["b", "q", 1, "p"], ["b", "r", 1, "q"], ["c", "p", 0, "p"], ["c", "q", 0, "p"]],
+        columns=["x", "y", "z", "yhat"],
+    )
     # when  explicit label values are given for categorical data
     # Pre training bias metrics
     with pytest.raises(


### PR DESCRIPTION
*Description of changes:*
Update report-use labelIndex for label, drop facet, label columns from dataset. When trying to create report, the data need not (and should not) contain the original facet and label columns once the sensitiveFacetIndex, positiveLabelIndex and positivePredictedIndex are included. So, we should drop it. This is really important when it comes to the FT metric where we should be careful which columns are included in the dataframe passed to the KNNClassifier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
