### PR TITLE
[DO NOT REVIEW] binary classification with str labels and probability predictions.

### DIFF
--- a/src/famly/bias/report.py
+++ b/src/famly/bias/report.py
@@ -355,9 +355,7 @@ def bias_report(
         raise ValueError("Positive label values or thresholds are empty for Label column")
     if isinstance(predicted_label_column, LabelColumn) and predicted_label_column.positive_label_values:
         if predicted_label_column.positive_label_values != label_column.positive_label_values:
-            raise ValueError(
-                "Positive predicted label values or threshold should be empty or same as label values or thresholds"
-            )
+            logger.warning("positive_label_values are not the same for labels and predicted labels")
     if not predicted_label_column and stage_type == StageType.POST_TRAINING:
         raise ValueError("predicted_label_column has to be provided for Post training metrics")
     data_series: pd.Series = df[facet_column.name]
@@ -381,7 +379,7 @@ def bias_report(
         positive_predicted_label_index = _positive_predicted_index(
             predicted_label_data=predicted_label_series,
             label_data=label_series,
-            positive_label_values=predicted_label_column.positive_label_values,
+            positive_label_values=predicted_label_column.positive_label_values or [],
         )
         if predicted_label_column.name in df.columns:
             df = df.drop(predicted_label_column.name, 1)


### PR DESCRIPTION
*Issue #, if available:* 
expand support for binary classification tasks in which the data label requires specifying a positive label value. e.g. is {"yes", "no"} and the model output only contains a probability.

*Description of changes:*
We support the case in which the predicted label column has a different positive label value than the label column.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
