### PR TITLE
Fix KS metric

### DIFF
--- a/src/smclarify/bias/metrics/pretraining.py
+++ b/src/smclarify/bias/metrics/pretraining.py
@@ -172,7 +172,7 @@ def KS(label: pd.Series, sensitive_facet_index: pd.Series) -> float:
     :param sensitive_facet_index: boolean column indicating sensitive group
     :return: Kolmogorov-Smirnov metric
     """
-    return LP_norm(label, sensitive_facet_index, 1)
+    return LP_norm(label, sensitive_facet_index, np.inf)
 
 
 @registry.pretraining

--- a/tests/unit/bias/metrics/test_metrics.py
+++ b/tests/unit/bias/metrics/test_metrics.py
@@ -262,13 +262,13 @@ def test_KL():
 def test_KS():
     df = pd.DataFrame([["1", "a"], ["0", "a"], ["0", "b"], ["1", "b"], ["1", "b"]], columns=["label", "x"])
     result = KS(df["label"], df["x"] == "b")
-    assert result == approx(0.33333333)
+    assert result == approx(0.16666666)
 
     result = KS(DATASET_PDF["label"], DATASET_PDF["x"] != "b")
-    assert result == approx(0.66666666)
+    assert result == approx(0.33333333)
 
     result = KS(DATASET_PDF["positive_label_index"], DATASET_PDF["x"] != "b")
-    assert result == approx(0.66666666)
+    assert result == approx(0.33333333)
 
 
 def test_JS():

--- a/tests/unit/bias/test_report.py
+++ b/tests/unit/bias/test_report.py
@@ -209,7 +209,7 @@ def test_report_continuous_data():
                 },
                 {"description": "Jensen-Shannon Divergence (JS)", "name": "JS", "value": 0.012610670256663018},
                 {"description": "Kullback-Liebler Divergence (KL)", "name": "KL", "value": 0.057704603668062765},
-                {"description": "Kolmogorov-Smirnov Distance (KS)", "name": "KS", "value": 0.2097902097902098},
+                {"description": "Kolmogorov-Smirnov Distance (KS)", "name": "KS", "value": 0.1048951048951049},
                 {"description": "L-p Norm (LP)", "name": "LP", "value": 0.14834407996920576},
                 {"description": "Total Variation Distance (TVD)", "name": "TVD", "value": 0.1048951048951049},
             ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
KS metric currently returns `sum(abs(Pa-Pd))`. It should return `max(abs(Pa - Pd))`
This is fixed by changing ord for [np.linarg.norm](https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
