### PR TITLE
Fix mypy/unit tests errors exposed by mypy/numpy version upgrade

### DIFF
--- a/src/smclarify/bias/metrics/posttraining.py
+++ b/src/smclarify/bias/metrics/posttraining.py
@@ -7,6 +7,8 @@ Post training metrics
 The metrics defined in this file must be computed after training the model.
 """
 import logging
+from typing import List
+
 import pandas as pd
 import numpy as np
 from sklearn.neighbors import KNeighborsClassifier
@@ -317,15 +319,15 @@ def TE(
     return te
 
 
-def FlipSet_pos(dataset: np.array, labels: np.array, predicted_labels: np.array) -> np.array:
+def FlipSet_pos(dataset: List, labels: List, predicted_labels: np.ndarray) -> np.ndarray:
     return np.array([dataset[i] for i in range(len(dataset)) if labels[i] > predicted_labels[i]])
 
 
-def FlipSet_neg(dataset: np.array, labels: np.array, predicted_labels: np.array) -> np.array:
+def FlipSet_neg(dataset: List, labels: List, predicted_labels: np.ndarray) -> np.ndarray:
     return np.array([dataset[i] for i in range(len(dataset)) if labels[i] < predicted_labels[i]])
 
 
-def FlipSet(dataset: np.array, labels: np.array, predicted_labels: np.array) -> np.array:
+def FlipSet(dataset: List, labels: List, predicted_labels: np.ndarray) -> np.ndarray:
     return np.array([dataset[i] for i in range(len(dataset)) if labels[i] != predicted_labels[i]])
 
 

--- a/src/smclarify/util/__init__.py
+++ b/src/smclarify/util/__init__.py
@@ -1,5 +1,4 @@
 import numpy as np
-from collections import defaultdict
 from functional import seq
 from typing import List
 
@@ -16,7 +15,7 @@ def collapse_to_binary(values, pivot=0.0):
     return np.array(nvalues)
 
 
-def GaussianFilter(input_array: np.array, sigma: int = 1) -> np.array:
+def GaussianFilter(input_array: np.ndarray, sigma: int = 1) -> np.ndarray:
     """
     :param input_array: array which Gaussian Filter is applied to
     :param sigma: integer which indicates standard deviation of the desired Gaussian distribution
@@ -49,7 +48,7 @@ def pdf(xs) -> dict:
     return result_pdf
 
 
-def pdfs_aligned_nonzero(*args) -> List[np.array]:
+def pdfs_aligned_nonzero(*args) -> List[np.ndarray]:
     """
     Convert a list of discrete pdfs / freq counts to aligned numpy arrays of the same size for common non-zero elements
     :return: pair of numpy arrays of the same size with the aligned pdfs
@@ -69,7 +68,7 @@ def pdfs_aligned_nonzero(*args) -> List[np.array]:
     dict_pdfs = seq(pdfs).map(dict).list()
 
     # result aligned lists
-    aligned_lists: List[List[np.array]] = [[] for x in range(num_pdfs)]
+    aligned_lists: List[List] = [[] for x in range(num_pdfs)]
 
     # fill keys present in all pdfs
     for i, key in enumerate(all_keys):

--- a/tests/unit/bias/test_report.py
+++ b/tests/unit/bias/test_report.py
@@ -113,19 +113,35 @@ def test_report_category_data():
                 {
                     "description": "Conditional Demographic Disparity in Labels " "(CDDL)",
                     "name": "CDDL",
-                    "value": -0.375,
+                    "value": pytest.approx(-0.375),
                 },
-                {"description": "Class Imbalance (CI)", "name": "CI", "value": 0.5},
+                {"description": "Class Imbalance (CI)", "name": "CI", "value": pytest.approx(0.5)},
                 {
                     "description": "Difference in Positive Proportions in Labels (DPL)",
                     "name": "DPL",
-                    "value": -0.6666666666666667,
+                    "value": pytest.approx(-0.6666666666666667),
                 },
-                {"description": "Jensen-Shannon Divergence (JS)", "name": "JS", "value": 0.2789960722619452},
-                {"description": "Kullback-Liebler Divergence (KL)", "name": "KL", "value": -0.3662040962227032},
-                {"description": "Kolmogorov-Smirnov Distance (KS)", "name": "KS", "value": 0.6666666666666667},
-                {"description": "L-p Norm (LP)", "name": "LP", "value": 0.6666666666666667},
-                {"description": "Total Variation Distance (TVD)", "name": "TVD", "value": 0.33333333333333337},
+                {
+                    "description": "Jensen-Shannon Divergence (JS)",
+                    "name": "JS",
+                    "value": pytest.approx(0.2789960722619452),
+                },
+                {
+                    "description": "Kullback-Liebler Divergence (KL)",
+                    "name": "KL",
+                    "value": pytest.approx(-0.3662040962227032),
+                },
+                {
+                    "description": "Kolmogorov-Smirnov Distance (KS)",
+                    "name": "KS",
+                    "value": pytest.approx(0.6666666666666667),
+                },
+                {"description": "L-p Norm (LP)", "name": "LP", "value": pytest.approx(0.6666666666666667)},
+                {
+                    "description": "Total Variation Distance (TVD)",
+                    "name": "TVD",
+                    "value": pytest.approx(0.33333333333333337),
+                },
             ],
             "value_or_threshold": "a",
         },
@@ -134,19 +150,35 @@ def test_report_category_data():
                 {
                     "description": "Conditional Demographic Disparity in Labels " "(CDDL)",
                     "name": "CDDL",
-                    "value": 0.625,
+                    "value": pytest.approx(0.625),
                 },
-                {"description": "Class Imbalance (CI)", "name": "CI", "value": -0.5},
+                {"description": "Class Imbalance (CI)", "name": "CI", "value": pytest.approx(-0.5)},
                 {
                     "description": "Difference in Positive Proportions in Labels (DPL)",
                     "name": "DPL",
-                    "value": 0.6666666666666667,
+                    "value": pytest.approx(0.6666666666666667),
                 },
-                {"description": "Jensen-Shannon Divergence (JS)", "name": "JS", "value": 0.2789960722619452},
-                {"description": "Kullback-Liebler Divergence (KL)", "name": "KL", "value": 1.0986122886681098},
-                {"description": "Kolmogorov-Smirnov Distance (KS)", "name": "KS", "value": 0.6666666666666667},
-                {"description": "L-p Norm (LP)", "name": "LP", "value": 0.6666666666666667},
-                {"description": "Total Variation Distance (TVD)", "name": "TVD", "value": 0.33333333333333337},
+                {
+                    "description": "Jensen-Shannon Divergence (JS)",
+                    "name": "JS",
+                    "value": pytest.approx(0.2789960722619452),
+                },
+                {
+                    "description": "Kullback-Liebler Divergence (KL)",
+                    "name": "KL",
+                    "value": pytest.approx(1.0986122886681098),
+                },
+                {
+                    "description": "Kolmogorov-Smirnov Distance (KS)",
+                    "name": "KS",
+                    "value": pytest.approx(0.6666666666666667),
+                },
+                {"description": "L-p Norm (LP)", "name": "LP", "value": pytest.approx(0.6666666666666667)},
+                {
+                    "description": "Total Variation Distance (TVD)",
+                    "name": "TVD",
+                    "value": pytest.approx(0.33333333333333337),
+                },
             ],
             "value_or_threshold": "b",
         },
@@ -181,27 +213,27 @@ def test_report_category_data():
     expected_result_1 = [
         {
             "metrics": [
-                {"description": "Accuracy Difference (AD)", "name": "AD", "value": -0.6666666666666667},
-                {"description": "Disparate Impact (DI)", "name": "DI", "value": 3.0},
+                {"description": "Accuracy Difference (AD)", "name": "AD", "value": pytest.approx(-0.6666666666666667)},
+                {"description": "Disparate Impact (DI)", "name": "DI", "value": pytest.approx(3.0)},
                 {
                     "description": "Difference in Positive Proportions in Predicted " "Labels (DPPL)",
                     "name": "DPPL",
-                    "value": -0.6666666666666667,
+                    "value": pytest.approx(-0.6666666666666667),
                 },
-                {"description": "Recall Difference (RD)", "name": "RD", "value": -1.0},
+                {"description": "Recall Difference (RD)", "name": "RD", "value": pytest.approx(-1.0)},
             ],
             "value_or_threshold": "a",
         },
         {
             "metrics": [
-                {"description": "Accuracy Difference (AD)", "name": "AD", "value": 0.6666666666666667},
-                {"description": "Disparate Impact (DI)", "name": "DI", "value": 0.3333333333333333},
+                {"description": "Accuracy Difference (AD)", "name": "AD", "value": pytest.approx(0.6666666666666667)},
+                {"description": "Disparate Impact (DI)", "name": "DI", "value": pytest.approx(0.3333333333333333)},
                 {
                     "description": "Difference in Positive Proportions in Predicted " "Labels (DPPL)",
                     "name": "DPPL",
-                    "value": 0.6666666666666667,
+                    "value": pytest.approx(0.6666666666666667),
                 },
-                {"description": "Recall Difference (RD)", "name": "RD", "value": 1.0},
+                {"description": "Recall Difference (RD)", "name": "RD", "value": pytest.approx(1.0)},
             ],
             "value_or_threshold": "b",
         },
@@ -259,19 +291,35 @@ def test_report_continuous_data():
                 {
                     "description": "Conditional Demographic Disparity in Labels " "(CDDL)",
                     "name": "CDDL",
-                    "value": 0.3851010101010101,
+                    "value": pytest.approx(0.3851010101010101),
                 },
-                {"description": "Class Imbalance (CI)", "name": "CI", "value": -0.08333333333333333},
+                {"description": "Class Imbalance (CI)", "name": "CI", "value": pytest.approx(-0.08333333333333333)},
                 {
                     "description": "Difference in Positive Proportions in Labels (DPL)",
                     "name": "DPL",
-                    "value": 0.1048951048951049,
+                    "value": pytest.approx(0.1048951048951049),
                 },
-                {"description": "Jensen-Shannon Divergence (JS)", "name": "JS", "value": 0.012610670256663018},
-                {"description": "Kullback-Liebler Divergence (KL)", "name": "KL", "value": 0.057704603668062765},
-                {"description": "Kolmogorov-Smirnov Distance (KS)", "name": "KS", "value": 0.1048951048951049},
-                {"description": "L-p Norm (LP)", "name": "LP", "value": 0.14834407996920576},
-                {"description": "Total Variation Distance (TVD)", "name": "TVD", "value": 0.1048951048951049},
+                {
+                    "description": "Jensen-Shannon Divergence (JS)",
+                    "name": "JS",
+                    "value": pytest.approx(0.012610670256663018),
+                },
+                {
+                    "description": "Kullback-Liebler Divergence (KL)",
+                    "name": "KL",
+                    "value": pytest.approx(0.057704603668062765),
+                },
+                {
+                    "description": "Kolmogorov-Smirnov Distance (KS)",
+                    "name": "KS",
+                    "value": pytest.approx(0.1048951048951049),
+                },
+                {"description": "L-p Norm (LP)", "name": "LP", "value": pytest.approx(0.14834407996920576)},
+                {
+                    "description": "Total Variation Distance (TVD)",
+                    "name": "TVD",
+                    "value": pytest.approx(0.1048951048951049),
+                },
             ],
             "value_or_threshold": "(2, 4]",
         }
@@ -292,25 +340,37 @@ def test_report_continuous_data():
     expected_result_1 = [
         {
             "metrics": [
-                {"description": "Accuracy Difference (AD)", "name": "AD", "value": -0.2167832167832168},
+                {"description": "Accuracy Difference (AD)", "name": "AD", "value": pytest.approx(-0.2167832167832168)},
                 {
                     "description": "Conditional Demographic Disparity in Predicted " "Labels (CDDPL)",
                     "name": "CDDPL",
-                    "value": 0.07592592592592595,
+                    "value": pytest.approx(0.07592592592592595),
                 },
-                {"description": "Difference in Acceptance Rates (DAR)", "name": "DAR", "value": -0.1},
-                {"description": "Difference in Conditional Acceptance (DCA)", "name": "DCA", "value": 0.15},
-                {"description": "Difference in Conditional Rejection (DCR)", "name": "DCR", "value": 1.0},
-                {"description": "Disparate Impact (DI)", "name": "DI", "value": 1.0576923076923077},
+                {"description": "Difference in Acceptance Rates (DAR)", "name": "DAR", "value": pytest.approx(-0.1)},
+                {
+                    "description": "Difference in Conditional Acceptance (DCA)",
+                    "name": "DCA",
+                    "value": pytest.approx(0.15),
+                },
+                {
+                    "description": "Difference in Conditional Rejection (DCR)",
+                    "name": "DCR",
+                    "value": pytest.approx(1.0),
+                },
+                {"description": "Disparate Impact (DI)", "name": "DI", "value": pytest.approx(1.0576923076923077)},
                 {
                     "description": "Difference in Positive Proportions in Predicted " "Labels (DPPL)",
                     "name": "DPPL",
-                    "value": -0.04195804195804198,
+                    "value": pytest.approx(-0.04195804195804198),
                 },
-                {"description": "Difference in Rejection Rates (DRR)", "name": "DRR", "value": 0.6666666666666667},
-                {"description": "Flip Test (FT)", "name": "FT", "value": -0.23076923076923078},
-                {"description": "Recall Difference (RD)", "name": "RD", "value": -1.0},
-                {"description": "Treatment Equality (TE)", "name": "TE", "value": -0.25},
+                {
+                    "description": "Difference in Rejection Rates (DRR)",
+                    "name": "DRR",
+                    "value": pytest.approx(0.6666666666666667),
+                },
+                {"description": "Flip Test (FT)", "name": "FT", "value": pytest.approx(-0.23076923076923078)},
+                {"description": "Recall Difference (RD)", "name": "RD", "value": pytest.approx(-1.0)},
+                {"description": "Treatment Equality (TE)", "name": "TE", "value": pytest.approx(-0.25)},
             ],
             "value_or_threshold": "(2, 4]",
         }
@@ -430,25 +490,45 @@ def test_label_values():
     expected_result_1 = [
         {
             "metrics": [
-                {"description": "Conditional Demographic Disparity in Labels " "(CDDL)", "name": "CDDL", "value": -0.3},
-                {"description": "Difference in Positive Proportions in Labels " "(DPL)", "name": "DPL", "value": -0.25},
+                {
+                    "description": "Conditional Demographic Disparity in Labels " "(CDDL)",
+                    "name": "CDDL",
+                    "value": pytest.approx(-0.3),
+                },
+                {
+                    "description": "Difference in Positive Proportions in Labels " "(DPL)",
+                    "name": "DPL",
+                    "value": pytest.approx(-0.25),
+                },
             ],
             "value_or_threshold": "a",
         },
         {
             "metrics": [
-                {"description": "Conditional Demographic Disparity in Labels " "(CDDL)", "name": "CDDL", "value": 0.3},
-                {"description": "Difference in Positive Proportions in Labels " "(DPL)", "name": "DPL", "value": 0.5},
+                {
+                    "description": "Conditional Demographic Disparity in Labels " "(CDDL)",
+                    "name": "CDDL",
+                    "value": pytest.approx(0.3),
+                },
+                {
+                    "description": "Difference in Positive Proportions in Labels " "(DPL)",
+                    "name": "DPL",
+                    "value": pytest.approx(0.5),
+                },
             ],
             "value_or_threshold": "b",
         },
         {
             "metrics": [
-                {"description": "Conditional Demographic Disparity in Labels " "(CDDL)", "name": "CDDL", "value": -0.4},
+                {
+                    "description": "Conditional Demographic Disparity in Labels " "(CDDL)",
+                    "name": "CDDL",
+                    "value": pytest.approx(-0.4),
+                },
                 {
                     "description": "Difference in Positive Proportions in Labels (DPL)",
                     "name": "DPL",
-                    "value": -0.33333333333333337,
+                    "value": pytest.approx(-0.33333333333333337),
                 },
             ],
             "value_or_threshold": "c",
@@ -471,46 +551,50 @@ def test_label_values():
     expected_result_2 = [
         {
             "metrics": [
-                {"description": "Accuracy Difference (AD)", "name": "AD", "value": -0.25},
-                {"description": "Difference in Acceptance Rates (DAR)", "name": "DAR", "value": -0.25},
-                {"description": "Disparate Impact (DI)", "name": "DI", "value": 1.0},
+                {"description": "Accuracy Difference (AD)", "name": "AD", "value": pytest.approx(-0.25)},
+                {"description": "Difference in Acceptance Rates (DAR)", "name": "DAR", "value": pytest.approx(-0.25)},
+                {"description": "Disparate Impact (DI)", "name": "DI", "value": pytest.approx(1.0)},
                 {
                     "description": "Difference in Positive Proportions in Predicted " "Labels (DPPL)",
                     "name": "DPPL",
-                    "value": 0.0,
+                    "value": pytest.approx(0.0),
                 },
-                {"description": "Difference in Rejection Rates (DRR)", "name": "DRR", "value": 0},
-                {"description": "Recall Difference (RD)", "name": "RD", "value": 0.0},
+                {"description": "Difference in Rejection Rates (DRR)", "name": "DRR", "value": pytest.approx(0)},
+                {"description": "Recall Difference (RD)", "name": "RD", "value": pytest.approx(0.0)},
             ],
             "value_or_threshold": "a",
         },
         {
             "metrics": [
-                {"description": "Accuracy Difference (AD)", "name": "AD", "value": 0.5},
-                {"description": "Difference in Acceptance Rates (DAR)", "name": "DAR", "value": 0.5},
-                {"description": "Disparate Impact (DI)", "name": "DI", "value": 1.0},
+                {"description": "Accuracy Difference (AD)", "name": "AD", "value": pytest.approx(0.5)},
+                {"description": "Difference in Acceptance Rates (DAR)", "name": "DAR", "value": pytest.approx(0.5)},
+                {"description": "Disparate Impact (DI)", "name": "DI", "value": pytest.approx(1.0)},
                 {
                     "description": "Difference in Positive Proportions in Predicted " "Labels (DPPL)",
                     "name": "DPPL",
-                    "value": 0.0,
+                    "value": pytest.approx(0.0),
                 },
-                {"description": "Difference in Rejection Rates (DRR)", "name": "DRR", "value": 0},
-                {"description": "Recall Difference (RD)", "name": "RD", "value": 0.0},
+                {"description": "Difference in Rejection Rates (DRR)", "name": "DRR", "value": pytest.approx(0)},
+                {"description": "Recall Difference (RD)", "name": "RD", "value": pytest.approx(0.0)},
             ],
             "value_or_threshold": "b",
         },
         {
             "metrics": [
-                {"description": "Accuracy Difference (AD)", "name": "AD", "value": -0.33333333333333337},
-                {"description": "Difference in Acceptance Rates (DAR)", "name": "DAR", "value": -0.33333333333333337},
-                {"description": "Disparate Impact (DI)", "name": "DI", "value": 1.0},
+                {"description": "Accuracy Difference (AD)", "name": "AD", "value": pytest.approx(-0.33333333333333337)},
+                {
+                    "description": "Difference in Acceptance Rates (DAR)",
+                    "name": "DAR",
+                    "value": pytest.approx(-0.33333333333333337),
+                },
+                {"description": "Disparate Impact (DI)", "name": "DI", "value": pytest.approx(1.0)},
                 {
                     "description": "Difference in Positive Proportions in Predicted " "Labels (DPPL)",
                     "name": "DPPL",
-                    "value": 0.0,
+                    "value": pytest.approx(0.0),
                 },
-                {"description": "Difference in Rejection Rates (DRR)", "name": "DRR", "value": 0},
-                {"description": "Recall Difference (RD)", "name": "RD", "value": 0.0},
+                {"description": "Difference in Rejection Rates (DRR)", "name": "DRR", "value": pytest.approx(0)},
+                {"description": "Recall Difference (RD)", "name": "RD", "value": pytest.approx(0.0)},
             ],
             "value_or_threshold": "c",
         },
@@ -558,9 +642,17 @@ def test_partial_bias_report():
                     "name": "CDDL",
                     "value": None,
                 },
-                {"description": "Class Imbalance (CI)", "name": "CI", "value": 0.6},
-                {"description": "Difference in Positive Proportions in Labels " "(DPL)", "name": "DPL", "value": 0.5},
-                {"description": "Kullback-Liebler Divergence (KL)", "name": "KL", "value": -0.34657359027997264},
+                {"description": "Class Imbalance (CI)", "name": "CI", "value": pytest.approx(0.6)},
+                {
+                    "description": "Difference in Positive Proportions in Labels " "(DPL)",
+                    "name": "DPL",
+                    "value": pytest.approx(0.5),
+                },
+                {
+                    "description": "Kullback-Liebler Divergence (KL)",
+                    "name": "KL",
+                    "value": pytest.approx(-0.34657359027997264),
+                },
             ],
             "value_or_threshold": "(2, 3]",
         }
@@ -580,7 +672,7 @@ def test_partial_bias_report():
     expected_result_2 = [
         {
             "metrics": [
-                {"description": "Accuracy Difference (AD)", "name": "AD", "value": -0.75},
+                {"description": "Accuracy Difference (AD)", "name": "AD", "value": pytest.approx(-0.75)},
                 {
                     "description": "Conditional Demographic Disparity in Predicted " "Labels (CDDPL)",
                     "error": "Group variable is empty or not provided",
@@ -590,15 +682,15 @@ def test_partial_bias_report():
                 {
                     "description": "Difference in Conditional Acceptance (DCA)",
                     "name": "DCA",
-                    "value": 0.6666666666666666,
+                    "value": pytest.approx(0.6666666666666666),
                 },
-                {"description": "Disparate Impact (DI)", "name": "DI", "value": 0.0},
+                {"description": "Disparate Impact (DI)", "name": "DI", "value": pytest.approx(0.0)},
                 {
                     "description": "Difference in Positive Proportions in Predicted " "Labels (DPPL)",
                     "name": "DPPL",
-                    "value": 0.75,
+                    "value": pytest.approx(0.75),
                 },
-                {"description": "Flip Test (FT)", "name": "FT", "value": -1.0},
+                {"description": "Flip Test (FT)", "name": "FT", "value": pytest.approx(-1.0)},
             ],
             "value_or_threshold": "(2, 3]",
         }


### PR DESCRIPTION
*Issue #, if available:*

No recent code change but master branch code started to fail the build, see https://github.com/xgchena/amazon-sagemaker-clarify/actions/runs/549041577

There are two types of errors,
* mypy failure (check the Python 3.8 build log)
* unit test failure (check the Python 3.7 build log)

They are exposed by dependency version upgrade
* mypy from 0.790 to 0.800
* numpy from 1.19.4 to 1.20.0 which supports [type annotations](https://numpy.org/neps/roadmap.html#type-annotations)

*Description of changes:*

The PR fixes the build errors,
* Remove the \_\_init\_\_.py file from the root folder to avoid "amazon-sagemaker-clarify is not a valid Python package name" error. (The new mypy version changed the behavior of scanning Python packages, in the old version, if the input is a relative path like "src" then it only scans the folder and its subfolders. But in the new version, it expand the relative path to absolute path and try to [crawl up](https://github.com/python/mypy/blame/9c54cc3f1c73150992345350be834f2987b3967d/mypy/find_sources.py#L181). I guess the behavioral change is to fix the infamous ". is not a valid Python package name" problem but it happens to expose the invalid init file issue of our package)
* Replace invalid type np.array by correct types np.ndarray or List to fix other mypy errors
* Add pytest.approx to unit test code to avoid test failures due to floating number precision. (I submitted an issue report to numpy project https://github.com/numpy/numpy/issues/18371 to confirm if it is an expected precision change or a bug of numpy.log, but the unit test fix is valid anyway because we are not supposed to compare floating numbers directly.)

Build passed: https://github.com/xgchena/amazon-sagemaker-clarify/actions/runs/549150380

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
