### PR TITLE
[bugfix] Fix JS metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,8 @@ It's recommended that you setup a virtualenv.
 virtualenv -p(which python3) venv
 source venv/bin/activate.fish
 pip install -e .[test]
-pytest --pspec
-pre-commit install && pre-commit run --all-files
+cd src/
+../devtool all
 ```
 
-Always run `pre-commit run --all-files` before commit or sending a pull request.
-
-
-For running unit tests, do `./test.sh` or `pytest --pspec`. If you are using PyCharm, and cannot see the green run button next to the tests, open `Preferences` -> `Tools` -> `Python Integrated tools`, and set default test runner to `pytest`.
+For running unit tests, do `pytest --pspec`. If you are using PyCharm, and cannot see the green run button next to the tests, open `Preferences` -> `Tools` -> `Python Integrated tools`, and set default test runner to `pytest`.

--- a/src/smclarify/bias/metrics/pretraining.py
+++ b/src/smclarify/bias/metrics/pretraining.py
@@ -108,11 +108,11 @@ def JS(label: pd.Series, sensitive_facet_index: pd.Series) -> float:
     require(sensitive_facet_index.dtype == bool, "sensitive_facet_index must be of type bool")
     xs_a = label[~sensitive_facet_index]
     xs_d = label[sensitive_facet_index]
-    (Pa, Pd, P) = pdfs_aligned_nonzero(xs_a, xs_d, label)
+    (Pa, Pd) = pdfs_aligned_nonzero(xs_a, xs_d)
+    P = 1 / 2 * (Pa + Pd)
     if len(Pa) == 0 or len(Pd) == 0 or len(P) == 0:
         raise ValueError("No instance of common facet found, dataset may be too small")
-    res = 0.5 * (np.sum(Pa * np.log(Pa / P)) + np.sum(Pd * np.log(Pd / P)))
-    return res
+    return 0.5 * (np.sum(Pa * np.log(Pa / P)) + np.sum(Pd * np.log(Pd / P)))
 
 
 @registry.pretraining

--- a/tests/integration/test_bias_metrics.py
+++ b/tests/integration/test_bias_metrics.py
@@ -99,7 +99,7 @@ def test_bias_metrics():
                     "description": "Difference in Positive Proportions in Labels (DPL)",
                     "value": 0.17453917050691248,
                 },
-                {"name": "JS", "description": "Jensen-Shannon Divergence (JS)", "value": 0.04021236938805562},
+                {"name": "JS", "description": "Jensen-Shannon Divergence (JS)", "value": 0.023326469309177138},
                 {"name": "KL", "description": "Kullback-Liebler Divergence (KL)", "value": 0.08543332780657628},
                 {"name": "KS", "description": "Kolmogorov-Smirnov Distance (KS)", "value": 0.17453917050691248},
                 {"name": "LP", "description": "L-p Norm (LP)", "value": 0.2468356620962257},

--- a/tests/unit/bias/metrics/test_metrics.py
+++ b/tests/unit/bias/metrics/test_metrics.py
@@ -8,6 +8,7 @@ from smclarify.bias.metrics.constants import INFINITY
 from pytest import approx
 import pandas as pd
 from pandas import Series
+import math
 import numpy as np
 import pytest
 
@@ -273,7 +274,7 @@ def test_KS():
 
 def test_JS():
     res = JS(pd.Series([True, True, True, False, False, False]), pd.Series([True, False, False, False, False, False]))
-    assert res == approx(0.3019448800171307)
+    assert res == approx(0.06641431438228168)
 
     res = JS(pd.Series([True, True, True, False, False, False]), pd.Series([True, False, False, False, True, False]))
     assert res == 0.0
@@ -291,7 +292,18 @@ def test_JS():
     res = JS(positive_label_index, sensitive_facet_index)
     assert res == approx(0.06465997)
 
-    return
+    # Calculate JS manually.
+    res = JS(pd.Series([True, True, True, True, False, False]), pd.Series([True, False, False, False, True, False]))
+    Pa = np.array([0.5, 0.5])
+    Pd = np.array([0.25, 0.75])
+    P = np.array([0.375, 0.625])
+    expected_result = 0.5 * (
+        (Pa[0] * math.log(Pa[0] / P[0]))
+        + (Pa[1] * math.log(Pa[1] / P[1]))
+        + (Pd[0] * math.log(Pd[0] / P[0]))
+        + (Pd[1] * math.log(Pd[1] / P[1]))
+    )
+    assert res == approx(expected_result)
 
 
 def test_LP():

--- a/tests/unit/bias/test_report.py
+++ b/tests/unit/bias/test_report.py
@@ -124,7 +124,7 @@ def test_report_category_data():
                 {
                     "description": "Jensen-Shannon Divergence (JS)",
                     "name": "JS",
-                    "value": pytest.approx(0.2789960722619452),
+                    "value": pytest.approx(0.08720802396075798),
                 },
                 {
                     "description": "Kullback-Liebler Divergence (KL)",
@@ -161,7 +161,7 @@ def test_report_category_data():
                 {
                     "description": "Jensen-Shannon Divergence (JS)",
                     "name": "JS",
-                    "value": pytest.approx(0.2789960722619452),
+                    "value": pytest.approx(0.08720802396075798),
                 },
                 {
                     "description": "Kullback-Liebler Divergence (KL)",
@@ -302,7 +302,7 @@ def test_report_continuous_data():
                 {
                     "description": "Jensen-Shannon Divergence (JS)",
                     "name": "JS",
-                    "value": pytest.approx(0.012610670256663018),
+                    "value": pytest.approx(0.01252420207928287),
                 },
                 {
                     "description": "Kullback-Liebler Divergence (KL)",


### PR DESCRIPTION
*Issue #, if available:* P44014016

*Description of changes:*
According to our developer [guide](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-data-bias-metric-jensen-shannon-divergence.html) for JS metric (which is aligned with the formula on wiki Jensen-Shannon divergence)

The formula for the Jensen-Shannon divergence is as follows:

   JS = ½*[KL(Pa || P) + KL(Pd || P)]

Where P = ½( Pa + Pd ), the average label distribution across facets a and d.

Instead we currently use the label distribution in the dataset. This PR fixes this bug reported by Xiaoguang.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Tested: used in the Container as package. 
