### PR TITLE
Bump up version to 0.2 for new release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ data_files = ["COMMIT_HASH"] if os.path.exists("./src/smclarify/COMMIT_HASH") el
 
 setup(
     name="smclarify",
-    version="0.1",
+    version="0.2",
     packages=find_packages("src"),
     package_dir={"": "src"},
     package_data={"smclarify": data_files},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A patch release to fix a JS metric problem.

[Github action](https://github.com/xgchena/amazon-sagemaker-clarify/actions/runs/615274898) (The version number change should have no impact on tests)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
