### PR TITLE
Add confusion matrix and proportion for each facet.

### DIFF
--- a/src/smclarify/bias/metrics/__init__.py
+++ b/src/smclarify/bias/metrics/__init__.py
@@ -4,6 +4,7 @@ import inspect
 from .posttraining import *
 from .pretraining import *
 
+from . import basic_stats
 from . import pretraining
 from . import posttraining
 from . import registry

--- a/src/smclarify/bias/metrics/basic_stats.py
+++ b/src/smclarify/bias/metrics/basic_stats.py
@@ -1,0 +1,41 @@
+import logging
+from typing import List
+
+import pandas as pd
+from .common import divide
+
+log = logging.getLogger(__name__)
+
+
+def confusion_matrix(
+    feature: pd.Series,
+    sensitive_facet_index: pd.Series,
+    positive_label_index: pd.Series,
+    positive_predicted_label_index: pd.Series,
+) -> List[float]:
+    r"""
+    Fractions of TP, FP, FN, TN.
+
+    :param feature: input feature
+    :param sensitive_facet_index: boolean column indicating sensitive group
+    :param positive_label_index: boolean column indicating positive labels
+    :param positive_predicted_label_index: boolean column indicating positive predicted labels
+    :return list of fractions of true positives, false positives, false negatives, true negatives
+    """
+    TP_d = len(feature[positive_label_index & positive_predicted_label_index & sensitive_facet_index])
+    FN_d = len(feature[positive_label_index & (~positive_predicted_label_index) & sensitive_facet_index])
+
+    TN_d = len(feature[(~positive_label_index) & (~positive_predicted_label_index) & sensitive_facet_index])
+    FP_d = len(feature[(~positive_label_index) & positive_predicted_label_index & sensitive_facet_index])
+    size = len(feature[sensitive_facet_index])
+    return [divide(TP_d, size), divide(FP_d, size), divide(FN_d, size), divide(TN_d, size)]
+
+
+def proportion(sensitive_facet_index: pd.Series) -> float:
+    r"""
+    Proportion of examples in sensitive facet.
+
+    :param sensitive_facet_index: boolean column indicating sensitive group
+    :return: the fraction of examples in the sensitive facet.
+    """
+    return sum(sensitive_facet_index) / len(sensitive_facet_index)

--- a/tests/unit/bias/metrics/test_basic_stats.py
+++ b/tests/unit/bias/metrics/test_basic_stats.py
@@ -1,0 +1,37 @@
+from smclarify.bias.metrics import basic_stats
+
+from .test_metrics import dfBinary
+
+from pytest import approx
+
+
+(dfB, dfB_label, dfB_pos_label_idx, dfB_pred_label, dfB_pos_pred_label_idx) = dfBinary()
+
+
+def test_proportion():
+    sensitive_facet_index = dfB[0] == "F"
+    assert basic_stats.proportion(sensitive_facet_index) == approx(7 / 12)
+
+    sensitive_facet_index = dfB[0] == "M"
+    assert basic_stats.proportion(sensitive_facet_index) == approx(5 / 12)
+
+
+def test_confusion_matrix():
+    # Binary Facet, Binary Label
+    sensitive_facet_index = dfB[0] == "F"
+    TP = approx(2 / 7.0)
+    TN = approx(2 / 7.0)
+    FP = approx(2 / 7.0)
+    FN = approx(1 / 7.0)
+    assert [TP, FP, FN, TN] == basic_stats.confusion_matrix(
+        dfB[0], sensitive_facet_index, dfB_pos_label_idx, dfB_pos_pred_label_idx
+    )
+
+    sensitive_facet_index = dfB[0] == "M"
+    TP = 0
+    TN = approx(1 / 5.0)
+    FP = approx(2 / 5.0)
+    FN = approx(2 / 5.0)
+    assert [TP, FP, FN, TN] == basic_stats.confusion_matrix(
+        dfB[0], sensitive_facet_index, dfB_pos_label_idx, dfB_pos_pred_label_idx
+    )


### PR DESCRIPTION
*Description of changes:* 

We add a new method `bias_basic_stats` that computes the proportion and confusion matrix. These basic statistics can provide a good overview before diving into the pre/post training bias metrics.


Example report of basic status:

`[{'value_or_threshold': 'a', 'metrics': [{'name': 'proportion', 'description': 'Proportion of examples in sensitive facet.', 'value': 0.25}, {'name': 'confusion_matrix', 'description': 'Fractions of TP, FP, FN, TN.', 'value': [1.0, 0.0, 0.0, 0.0]}]}, {'value_or_threshold': 'b', 'metrics': [{'name': 'proportion', 'description': 'Proportion of examples in sensitive facet.', 'value': 0.75}, {'name': 'confusion_matrix', 'description': 'Fractions of TP, FP, FN, TN.', 'value': [0.0, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333]}]}]`
