### PR TITLE
Fix bug when calculating thresholds

### DIFF
--- a/src/smclarify/bias/report.py
+++ b/src/smclarify/bias/report.py
@@ -160,7 +160,8 @@ def _interval_index(facet: pd.Series, thresholds: Optional[List[Any]]) -> pd.Int
     # add  max value if not exists in threshold limits
     if abs(facet_max) not in thresholds:
         threshold_intervals.append(facet_max)
-    return pd.IntervalIndex.from_breaks(threshold_intervals)
+    sorted_threshold_intervals = sorted(threshold_intervals)
+    return pd.IntervalIndex.from_breaks(sorted_threshold_intervals)
 
 
 def _positive_predicted_index(

--- a/tests/unit/bias/test_report.py
+++ b/tests/unit/bias/test_report.py
@@ -13,6 +13,7 @@ from smclarify.bias.report import (
     LabelColumn,
     fetch_metrics_to_run,
     StageType,
+    label_value_or_threshold,
 )
 from smclarify.bias.metrics import PRETRAINING_METRICS, POSTTRAINING_METRICS, CI, DPL, KL, KS, DPPL, DI, DCA, DCR, RD
 from smclarify.bias.metrics import common
@@ -858,3 +859,11 @@ def test_bias_basic_stats():
         },
     ]
     assert expected_results == results
+
+
+def test_thresholds_small_data():
+    """Test that for trivial dataset where labels don't have as many element as label_values thresholds are calculated correctly"""
+    data = pd.Series([0])
+    positive_values = [1]
+    res = label_value_or_threshold(data, positive_values)
+    assert res == "(0, 1]"


### PR DESCRIPTION
*Description of changes:*


Thresholds are not correct when there's less values in labels vs the ones in the thresholds, leading to trying to create an interval with [1,0] for example which should be [0, 1] which would raise an exception inside pandas.

Added a test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
