### PR TITLE
Fix bug: TypeError when calculating abs value of "CONTINUOUS" data

### DIFF
--- a/devtool
+++ b/devtool
@@ -43,7 +43,7 @@ lint() {
 test_with_coverage() {
     scripts/run_examples.py
     coverage run -m pytest --pspec tests/unit
-    coverage report -m --fail-under=72
+    coverage report -m --fail-under=88
 }
 
 docs() {

--- a/src/smclarify/bias/metrics/common.py
+++ b/src/smclarify/bias/metrics/common.py
@@ -4,7 +4,7 @@
 
 import logging
 from enum import Enum
-from typing import List, Optional, Tuple, Callable
+from typing import List, Optional, Tuple, Callable, Any
 import pandas as pd
 import numpy as np
 from smclarify.bias.metrics.constants import INFINITY
@@ -111,9 +111,11 @@ def CDD(
     return wtd_mean_CDD
 
 
-def series_datatype(data: pd.Series, values: Optional[List[str]] = None) -> DataType:
+def series_datatype(data: pd.Series, values: Optional[List[Any]] = None) -> DataType:
     """
-    determine given data series is categorical or continuous using set of rules
+    Determine given data series is categorical or continuous using set of rules.
+    WARNING: The deduced data type can be different from real data type of the data series. Please
+    use the function `ensure_series_data_type` instead if you'd like ensure the series data type.
 
     :param data: data for facet/label/predicted_label columns
     :param values: list of facet or label values provided by user
@@ -147,6 +149,22 @@ def series_datatype(data: pd.Series, values: Optional[List[str]] = None) -> Data
         f"{data_type.name} column"
     )
     return data_type
+
+
+def ensure_series_data_type(data: pd.Series, values: Optional[List[Any]] = None) -> Tuple[DataType, pd.Series]:
+    """
+    Determine the type of the given data series using set of rules, and then do necessary type conversion
+    to ensure the series data type.
+    :param data: data for facet/label/predicted_label columns
+    :param values: list of facet or label values provided by user
+    :return: A tuple of DataType and the converted data series
+    """
+    data_type = series_datatype(data, values)
+    if data_type == DataType.CATEGORICAL:
+        return data_type, data.astype("category")
+    if data_type == DataType.CONTINUOUS:
+        return data_type, pd.to_numeric(data)
+    raise ValueError("Data series is invalid or can't be classified")
 
 
 # Todo: Fix the function to avoid redundant calls for DCA and DCR

--- a/tests/unit/bias/metrics/test_common.py
+++ b/tests/unit/bias/metrics/test_common.py
@@ -1,0 +1,90 @@
+from typing import NamedTuple, Optional, List, Any
+import pandas as pd
+import pytest
+
+from smclarify.bias.metrics.common import DataType, series_datatype, ensure_series_data_type
+
+
+class EnsureSeriesDataTypeInput(NamedTuple):
+    data: pd.Series
+    values: Optional[List[Any]] = None
+
+
+class EnsureSeriesDataTypeOutput(NamedTuple):
+    data_type: DataType
+    new_data: pd.Series
+
+
+def ensure_series_data_type_test_cases():
+    test_cases = []
+
+    # categorical data series
+    data = pd.Series([1, 2, 3]).astype("category")
+    function_input = EnsureSeriesDataTypeInput(data=data)
+    function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CATEGORICAL, new_data=data)
+    test_cases.append([function_input, function_output])
+
+    # categorical values
+    data = pd.Series([1, 2, 3])
+    function_input = EnsureSeriesDataTypeInput(data=data, values=[1, 2, 3])
+    function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CATEGORICAL, new_data=data.astype("category"))
+    test_cases.append([function_input, function_output])
+
+    # floating data series
+    data = pd.Series([1.0, 2.0, 3.0])
+    function_input = EnsureSeriesDataTypeInput(data=data)
+    function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CONTINUOUS, new_data=data)
+    test_cases.append([function_input, function_output])
+
+    # object data series, can NOT be converted to numeric
+    data = pd.Series(["a", "b", "c"])
+    function_input = EnsureSeriesDataTypeInput(data=data)
+    function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CATEGORICAL, new_data=data.astype("category"))
+    test_cases.append([function_input, function_output])
+
+    # object data series, can be converted to numeric, and uniqueness is high
+    data = pd.Series(["1", "2", "3"])
+    function_input = EnsureSeriesDataTypeInput(data=data)
+    function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CONTINUOUS, new_data=pd.to_numeric(data))
+    test_cases.append([function_input, function_output])
+
+    # object data series, can be converted to numeric, but uniqueness is low
+    data = ["1"] * 40
+    data.append("2")
+    data = pd.Series(data)
+    function_input = EnsureSeriesDataTypeInput(data=data)
+    function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CATEGORICAL, new_data=data.astype("category"))
+    test_cases.append([function_input, function_output])
+
+    # integer data series, uniqueness is high
+    data = pd.Series([1, 2, 3])
+    function_input = EnsureSeriesDataTypeInput(data=data)
+    function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CONTINUOUS, new_data=data)
+    test_cases.append([function_input, function_output])
+
+    # integer data series, uniqueness is low
+    data = [1] * 40
+    data.append(2)
+    data = pd.Series(data)
+    function_input = EnsureSeriesDataTypeInput(data=data)
+    function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CATEGORICAL, new_data=data.astype("category"))
+    test_cases.append([function_input, function_output])
+
+    # boolean data series
+    data = pd.Series([True, False, True])
+    function_input = EnsureSeriesDataTypeInput(data=data)
+    function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CATEGORICAL, new_data=data.astype("category"))
+    test_cases.append([function_input, function_output])
+
+    return test_cases
+
+
+@pytest.mark.parametrize("function_input,function_output", ensure_series_data_type_test_cases())
+def test_ensure_series_data_type(function_input, function_output):
+    # Test the series_datatype function by the way
+    data_type = series_datatype(*function_input)
+    assert data_type == function_output.data_type
+    # Test the ensure_series_data_type
+    data_type, new_data = ensure_series_data_type(*function_input)
+    assert data_type == function_output.data_type
+    assert new_data.equals(function_output.new_data)

--- a/tests/unit/bias/test_report.py
+++ b/tests/unit/bias/test_report.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
 # Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+from typing import NamedTuple, List, Any
 
 import pandas as pd
 import pytest
@@ -26,7 +27,7 @@ def test_invalid_input():
     )
     for staging_type in StageType:
         # facet not in dataset
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Facet column z is not present in the dataset"):
             bias_report(
                 df_cat,
                 FacetColumn("z"),
@@ -34,7 +35,7 @@ def test_invalid_input():
                 staging_type,
             )
         # no positive label value
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Positive label values or thresholds are empty for Label column"):
             bias_report(
                 df_cat,
                 FacetColumn("x"),
@@ -42,7 +43,7 @@ def test_invalid_input():
                 staging_type,
             )
     # incorrect stage type
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="stage_type should be a Enum value of StageType"):
         # noinspection PyTypeChecker
         bias_report(
             df_cat,
@@ -51,7 +52,7 @@ def test_invalid_input():
             "pre_training",
         )
     # post-training but no predicted label column
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="predicted_label_column has to be provided for Post training metrics"):
         bias_report(
             df_cat,
             FacetColumn("x"),
@@ -59,16 +60,19 @@ def test_invalid_input():
             StageType.POST_TRAINING,
         )
     # positive label value of label and predicted label not the same
-    with pytest.raises(ValueError):
+    match_message = "Positive predicted label values or threshold should be empty or same as label values or thresholds"
+    with pytest.raises(ValueError, match=match_message):
         bias_report(
             df_cat,
             FacetColumn("x"),
             LabelColumn("Label", df_cat["label"], [1]),
             StageType.POST_TRAINING,
-            LabelColumn("Prediction", df_cat["predicted_label"], [1]),
+            LabelColumn("Prediction", df_cat["predicted_label"], [0]),
         )
+
     # label and positive label have different data types.
-    with pytest.raises(ValueError):
+    match_message = "Predicted Label Column series datatype is not the same as Label Column series"
+    with pytest.raises(ValueError, match=match_message):
         bias_report(
             df_cat,
             FacetColumn("x"),
@@ -76,7 +80,25 @@ def test_invalid_input():
             StageType.POST_TRAINING,
             LabelColumn("Prediction", df_cat["predicted_label"], [1]),
         )
-    # TODO: add more test cases.
+
+    # threshold not provided for continuous facet
+    df = pd.DataFrame(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [2.0, 3.0, 4.0, 5.0],
+            [3.0, 4.0, 5.0, 6.0],
+            [4.0, 5.0, 6.0, 7.0],
+        ],
+        columns=["Label", "Facet", "Feature", "PredictedLabel"],
+    )
+    with pytest.raises(ValueError, match="Threshold values must be provided for continuous features"):
+        bias_report(
+            df=df,
+            facet_column=FacetColumn("Facet"),
+            label_column=LabelColumn("Label", df["Label"], [2.0]),
+            stage_type=StageType.POST_TRAINING,
+            predicted_label_column=LabelColumn("PredictedLabel", df["PredictedLabel"], [2.0]),
+        )
 
 
 def test_report_category_data():
@@ -466,6 +488,80 @@ def test_report_continuous_data_regression():
         group_variable=df_cont["z"],
     )
     assert posttraining_report == posttraining_report_old
+
+
+def test_report_string_data_determined_as_continuous():
+    # Although the data columns look like categorical, they are determined as continuous
+    # because the data can be casted to numbers, and the data uniqueness is high.
+    # The test case means to check if the report method can handle the case correctly.
+    df = pd.DataFrame(
+        data=[
+            ["1", "1", "1", "1"],
+            ["2", "2", "2", "2"],
+            ["3", "3", "3", "3"],
+            ["4", "4", "4", "4"],
+        ],
+        columns=["Label", "Facet", "Feature", "PredictedLabel"],
+    )
+    pretraining_report = bias_report(
+        df=df,
+        facet_column=FacetColumn("Facet", [2]),
+        label_column=LabelColumn("Label", df["Label"], [2]),
+        stage_type=StageType.POST_TRAINING,
+        predicted_label_column=LabelColumn("PredictedLabel", df["PredictedLabel"], [2]),
+        metrics=["DPPL"],
+    )
+    # Actually the validation below is not really needed. If there was problem then the report method
+    # should have failed with error like "TypeError: bad operand type for abs(): 'str'" when it tried to
+    # manipulate string as number.
+    assert pretraining_report == [
+        {
+            "value_or_threshold": "(2, 4]",  # <== range, so the facet is indeed determined as continuous
+            "metrics": [
+                {
+                    "name": "DPPL",
+                    "description": "Difference in Positive Proportions in Predicted " "Labels (DPPL)",
+                    "value": pytest.approx(-1.0),
+                }
+            ],
+        }
+    ]
+
+
+def test_report_integer_data_determined_as_categorical():
+    # Although the data columns look like continuous, they are determined as categorical because
+    # the facet values or label values are categorical. Note that the label column and the predicted
+    # label column have different categories (1,3,4 and 2,3,4 respectively). They can not be cast to
+    # the type of each other, but no problem to get the positive label index.
+    df = pd.DataFrame(
+        data=[
+            [1, 1, 1, 2],
+            [1, 2, 2, 2],
+            [3, 3, 3, 3],
+            [4, 4, 4, 4],
+        ],
+        columns=["Label", "Facet", "Feature", "PredictedLabel"],
+    )
+    pretraining_report = bias_report(
+        df=df,
+        facet_column=FacetColumn("Facet", [1, 2]),
+        label_column=LabelColumn("Label", df["Label"], [1, 2]),
+        stage_type=StageType.POST_TRAINING,
+        predicted_label_column=LabelColumn("PredictedLabel", df["PredictedLabel"], [1, 2]),
+        metrics=["DPPL"],
+    )
+    assert pretraining_report == [
+        {
+            "value_or_threshold": "1,2",  # <== range, so the facet is indeed determined as categorical
+            "metrics": [
+                {
+                    "name": "DPPL",
+                    "description": "Difference in Positive Proportions in Predicted " "Labels (DPPL)",
+                    "value": pytest.approx(-1.0),
+                }
+            ],
+        }
+    ]
 
 
 def test_label_values():
@@ -861,9 +957,69 @@ def test_bias_basic_stats():
     assert expected_results == results
 
 
-def test_thresholds_small_data():
-    """Test that for trivial dataset where labels don't have as many element as label_values thresholds are calculated correctly"""
+class LabelValueOrThresholdFunctionInput(NamedTuple):
+    data: pd.Series
+    values: List[Any]
+
+
+class LabelValueOrThresholdFunctionOutput(NamedTuple):
+    result: str
+
+
+def label_value_or_threshold_test_cases():
+    test_cases = []
+
+    # categorical data series
+    function_input = LabelValueOrThresholdFunctionInput(data=pd.Series([1, 2, 3]).astype("category"), values=[2])
+    function_output = LabelValueOrThresholdFunctionOutput(result="2")  # instead of "(2, 3]"
+    test_cases.append([function_input, function_output])
+
+    # categorical values
+    function_input = LabelValueOrThresholdFunctionInput(data=pd.Series([1, 2, 3]), values=[1, 2])
+    function_output = LabelValueOrThresholdFunctionOutput(result="1,2")
+    test_cases.append([function_input, function_output])
+
+    # continuous data series
+    function_input = LabelValueOrThresholdFunctionInput(data=pd.Series([1.0, 2.0, 3.0]), values=[2.0])
+    function_output = LabelValueOrThresholdFunctionOutput(result="(2.0, 3.0]")
+    test_cases.append([function_input, function_output])
+
+    # continuous data series, positive value less than all data
+    function_input = LabelValueOrThresholdFunctionInput(data=pd.Series([1.0, 2.0, 3.0]), values=[0.0])
+    function_output = LabelValueOrThresholdFunctionOutput(result="(0.0, 3.0]")
+    test_cases.append([function_input, function_output])
+
+    # continuous data series, positive value greater than all data
+    function_input = LabelValueOrThresholdFunctionInput(data=pd.Series([1.0, 2.0, 3.0]), values=[5.0])
+    function_output = LabelValueOrThresholdFunctionOutput(result="(3.0, 5.0]")
+    test_cases.append([function_input, function_output])
+
+    # object data series, can NOT be converted to numeric
+    function_input = LabelValueOrThresholdFunctionInput(data=pd.Series(["yes", "no", "yes"]), values=["yes"])
+    function_output = LabelValueOrThresholdFunctionOutput(result="yes")
+    test_cases.append([function_input, function_output])
+
+    # object data series, can be converted to numeric, and uniqueness is high
+    function_input = LabelValueOrThresholdFunctionInput(data=pd.Series(["1", "2", "3"]), values=[2])
+    function_output = LabelValueOrThresholdFunctionOutput(result="(2, 3]")
+    test_cases.append([function_input, function_output])
+
+    # boolean data series
+    function_input = LabelValueOrThresholdFunctionInput(data=pd.Series([True, False, True]), values=[True])
+    function_output = LabelValueOrThresholdFunctionOutput(result="True")
+    test_cases.append([function_input, function_output])
+
+    # Test that for trivial dataset where labels don't have as many element as label_values
     data = pd.Series([0])
     positive_values = [1]
-    res = label_value_or_threshold(data, positive_values)
-    assert res == "(0, 1]"
+    function_input = LabelValueOrThresholdFunctionInput(data=data, values=positive_values)
+    function_output = LabelValueOrThresholdFunctionOutput(result="(0, 1]")
+    test_cases.append([function_input, function_output])
+
+    return test_cases
+
+
+@pytest.mark.parametrize("function_input,function_output", label_value_or_threshold_test_cases())
+def test_label_value_or_threshold(function_input, function_output):
+    result = label_value_or_threshold(*function_input)
+    assert result == function_output.result


### PR DESCRIPTION
*Issue #, if available:*

https://tiny.amazon.com/r0677v90

*Description of changes:*

[_interval_index()](https://github.com/aws/amazon-sagemaker-clarify/blob/9ef3609a8c76f68f5669018b9966124c877e684c/src/smclarify/bias/report.py#L161) may raise "TypeError: bad operand type for abs(): 'str'" and the rootcause is that [series_datatype()](https://github.com/aws/amazon-sagemaker-clarify/blob/9ef3609a8c76f68f5669018b9966124c877e684c/src/smclarify/bias/metrics/common.py#L134) determined a string series as CONTINUOUS, but didn't convert the data to numeric.

The commit ensures consistency of the deduced DataType and the dtype of a data series.

Major changes:
* Deduce data type of facet series, label series and predicted label series, and then convert the series to category or numeric according to the data type. Use the converted data series (instead of the original data series) to calculate bias metrics.
* Keep the validations and preprocessing in `_report`, but move the actual reporting to `_do_report` for clarity (and to avoid using wrong data by chance e.g., label_data_series should be used, instead of label_column.data).
* Rename some variables for clarity, e.g. `data_series` => `facet_data_series`, 
* Fix the naming of parameters/variables in `_interval_index()`, the function is NOT just for facet.
* Fix the mypy type of facet/label values. It should be List[Any] instead of List[str]
* Add more unit tests and raise the code coverage bar

*Testing Done:*

* Local `devtool all` passed
* Local `devtool integ_tests` passed
* Installed the new whl to the analyzer repo and container `devtool all` passed.
* Github actions passed ([link](https://github.com/xgchena/amazon-sagemaker-clarify/actions/runs/1169239813))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
