### PR TITLE
Enforce a single threshold for continuous data config and update the lower bounds to be inclusive...

### DIFF
--- a/src/smclarify/bias/metrics/common.py
+++ b/src/smclarify/bias/metrics/common.py
@@ -7,6 +7,8 @@ from enum import Enum
 from typing import List, Optional, Tuple, Callable, Any
 import pandas as pd
 import numpy as np
+from numpy import ndarray
+
 from smclarify.bias.metrics.constants import INFINITY
 
 from smclarify.bias.metrics.constants import UNIQUENESS_THRESHOLD
@@ -94,8 +96,8 @@ def CDD(
 
     # Conditional demographic disparity (CDD)
     # FIXME: appending to numpy arrays is inefficient
-    CDD = np.array([])
-    counts = np.array([])
+    CDD: ndarray = np.array([])
+    counts: ndarray = np.array([])
     for subgroup_variable in unique_groups:
         counts = np.append(counts, len(group_variable[group_variable == subgroup_variable]))
         numA = len(feature[label_index & sensitive_facet_index & (group_variable == subgroup_variable)])

--- a/src/smclarify/bias/metrics/common.py
+++ b/src/smclarify/bias/metrics/common.py
@@ -51,7 +51,7 @@ def metric_description(metric: Callable[..., float]) -> str:
 
 def DPL(feature: pd.Series, sensitive_facet_index: pd.Series, positive_label_index: pd.Series) -> float:
     require(sensitive_facet_index.dtype == bool, "sensitive_facet_index must be of type bool")
-    require(positive_label_index.dtype == bool, "label_index must be of type bool")
+    require(positive_label_index.dtype == bool, "positive_label_index must be of type bool")
     na = len(feature[~sensitive_facet_index])
     nd = len(feature[sensitive_facet_index])
     na_pos = len(feature[~sensitive_facet_index & positive_label_index])

--- a/src/smclarify/bias/metrics/pretraining.py
+++ b/src/smclarify/bias/metrics/pretraining.py
@@ -138,7 +138,8 @@ def LP_norm(label: pd.Series, sensitive_facet_index: pd.Series, norm_order) -> f
     if len(Pa) == 0 or len(Pd) == 0:
         raise ValueError("No instance of common facet found, dataset may be too small")
     res = np.linalg.norm(Pa - Pd, norm_order)
-    return res
+    # res should only be a single float value, otherwise this metric is incorrect
+    return float(res)
 
 
 @registry.pretraining

--- a/src/smclarify/bias/metrics/pretraining.py
+++ b/src/smclarify/bias/metrics/pretraining.py
@@ -66,8 +66,6 @@ def DPL(feature: pd.Series, sensitive_facet_index: pd.Series, positive_label_ind
     :param positive_label_index: boolean column indicating positive labels
     :return: a float in the interval [-1, +1] indicating bias in the labels.
     """
-    require(sensitive_facet_index.dtype == bool, "sensitive_facet_index must be of type bool")
-    require(positive_label_index.dtype == bool, "positive_label_index must be of type bool")
     return common.DPL(feature, sensitive_facet_index, positive_label_index)
 
 

--- a/src/smclarify/bias/report.py
+++ b/src/smclarify/bias/report.py
@@ -148,7 +148,7 @@ def fetch_metrics_to_run(full_metrics: List[Callable[..., Any]], metric_names: L
 def _interval_index(data: pd.Series, thresholds: Optional[List[Any]]) -> pd.IntervalIndex:
     """
     Creates a Interval Index from list of threshold values. See pd.IntervalIndex.from_breaks
-    Ex. [0,1,2] -> [(0, 1], (1,2]]
+    Ex. [0,1,2] -> [[0, 1], [1,2]]
     :param data: input data series
     :param thresholds: list of int or float values defining the threshold splits
     :return: pd.IntervalIndex
@@ -160,8 +160,12 @@ def _interval_index(data: pd.Series, thresholds: Optional[List[Any]]) -> pd.Inte
     # add  max value if not exists in threshold limits
     if abs(max_value) not in thresholds:
         threshold_intervals.append(max_value)
+    # append duplicate value if only one threshold interval for edge case where max_value is the only value
+    # this is so from_breaks can create an interval containing the singular value
+    if len(threshold_intervals) == 1:
+        threshold_intervals.append(threshold_intervals[0])
     sorted_threshold_intervals = sorted(threshold_intervals)
-    return pd.IntervalIndex.from_breaks(sorted_threshold_intervals)
+    return pd.IntervalIndex.from_breaks(sorted_threshold_intervals, closed="both")
 
 
 def _positive_predicted_index(
@@ -175,6 +179,9 @@ def _positive_predicted_index(
     creates a list of bool series for positive predicted label index based on the input data type,
     list of positive label values or intervals
 
+    Note: For CONTINUOUS data, we currently only support having a single threshold, where all labels >= threshold
+    is considered a positive value.  See BiasConfig documentation.
+
     :param predicted_label_data: input data for predicted label column
     :param predicted_label_datatype: data type of the predicted label data
     :param label_data: input data for label column
@@ -185,6 +192,8 @@ def _positive_predicted_index(
     if predicted_label_datatype != label_datatype:
         raise ValueError("Predicted Label Column series datatype is not the same as Label Column series")
     if predicted_label_datatype == common.DataType.CONTINUOUS:
+        if len(positive_label_values) != 1:
+            raise ValueError("Only a single threshold is supported for continuous datatypes")
         predicted_label_data = predicted_label_data.astype(label_data.dtype)
         data_interval_indices = _interval_index(label_data.append(predicted_label_data), positive_label_values)
         positive_predicted_index = _continuous_data_idx(predicted_label_data, data_interval_indices)
@@ -208,12 +217,17 @@ def _positive_label_index(
     creates a list of bool series for positive label index based on the input data type, list of positive
     label values or intervals
 
+    Note: For CONTINUOUS data, we currently only support having a single threshold, where all labels >= threshold
+    is considered a positive value.  See BiasConfig documentation.
+
     :param data: input data for label column
     :param data_type: DataType of the label series data
     :param positive_values: list of positive label values
     :return: list of positive label index series, positive_label_values or intervals
     """
     if data_type == common.DataType.CONTINUOUS:
+        if len(positive_values) != 1:
+            raise ValueError("Only a single threshold is supported for continuous datatypes")
         data_interval_indices = _interval_index(data, positive_values)
         positive_index = _continuous_data_idx(data, data_interval_indices)
         label_values_or_intervals = ",".join(map(str, data_interval_indices))
@@ -547,6 +561,8 @@ def _do_report(
         return metrics_result
 
     elif facet_data_type == common.DataType.CONTINUOUS:
+        if sensitive_facet_values and len(sensitive_facet_values) > 1:
+            raise ValueError("Sensitive Facet Threshold must be a single value for continuous data")
         facet_interval_indices = _interval_index(facet_data_series, sensitive_facet_values)
         logger.info(f"Threshold Interval indices: {facet_interval_indices}")
         # list of metrics with values

--- a/tests/unit/bias/test_report.py
+++ b/tests/unit/bias/test_report.py
@@ -1055,4 +1055,3 @@ def test_interval_index_singular_threshold_interval_max_value():
     thresholds = [1000]
     res = _interval_index(data, thresholds)
     assert (res == pd.IntervalIndex.from_tuples([(1000, 1000)], closed="both").values).all()
-


### PR DESCRIPTION
Enforce a single threshold for continuous data config and update the lower bounds to be inclusive.  This naturally fixes a small edge case such as when threshold==max.

Lower bounds is currently ambiguous as to whether it is inclusive or exclusive: https://sagemaker.readthedocs.io/en/v2.77.1/api/training/processing.html#sagemaker.clarify.BiasConfig

Fixes a couple of type checks introduced by latest mypy==0.931

_Note:_ lower bounds change pending discussion

**_Testing**:_

- Local `devtool all` passed
- Local `devtool integ_tests` passed
- `devtool all` in analyzer repo passed with these changes (after analyzer changes)
- Github actions: https://github.com/spoorn/amazon-sagemaker-clarify/actions/runs/1931298794

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
