### PR TITLE
Add checks for threshold list for continuous data...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ venv/
 *.swp
 .docker/
 reports
+**.unison.tmp

--- a/src/smclarify/bias/metrics/common.py
+++ b/src/smclarify/bias/metrics/common.py
@@ -7,6 +7,8 @@ from enum import Enum
 from typing import List, Optional, Tuple, Callable, Any
 import pandas as pd
 import numpy as np
+from numpy import ndarray
+
 from smclarify.bias.metrics.constants import INFINITY
 
 from smclarify.bias.metrics.constants import UNIQUENESS_THRESHOLD
@@ -51,7 +53,7 @@ def metric_description(metric: Callable[..., float]) -> str:
 
 def DPL(feature: pd.Series, sensitive_facet_index: pd.Series, positive_label_index: pd.Series) -> float:
     require(sensitive_facet_index.dtype == bool, "sensitive_facet_index must be of type bool")
-    require(positive_label_index.dtype == bool, "label_index must be of type bool")
+    require(positive_label_index.dtype == bool, "positive_label_index must be of type bool")
     na = len(feature[~sensitive_facet_index])
     nd = len(feature[sensitive_facet_index])
     na_pos = len(feature[~sensitive_facet_index & positive_label_index])
@@ -94,8 +96,8 @@ def CDD(
 
     # Conditional demographic disparity (CDD)
     # FIXME: appending to numpy arrays is inefficient
-    CDD = np.array([])
-    counts = np.array([])
+    CDD: ndarray = np.array([])
+    counts: ndarray = np.array([])
     for subgroup_variable in unique_groups:
         counts = np.append(counts, len(group_variable[group_variable == subgroup_variable]))
         numA = len(feature[label_index & sensitive_facet_index & (group_variable == subgroup_variable)])

--- a/src/smclarify/bias/metrics/pretraining.py
+++ b/src/smclarify/bias/metrics/pretraining.py
@@ -140,7 +140,8 @@ def LP_norm(label: pd.Series, sensitive_facet_index: pd.Series, norm_order) -> f
     if len(Pa) == 0 or len(Pd) == 0:
         raise ValueError("No instance of common facet found, dataset may be too small")
     res = np.linalg.norm(Pa - Pd, norm_order)
-    return res
+    # res should only be a single float value, otherwise this metric is incorrect
+    return float(res)
 
 
 @registry.pretraining

--- a/tests/unit/bias/test_report.py
+++ b/tests/unit/bias/test_report.py
@@ -15,6 +15,9 @@ from smclarify.bias.report import (
     fetch_metrics_to_run,
     StageType,
     label_value_or_threshold,
+    _positive_predicted_index,
+    _positive_label_index,
+    _interval_index,
 )
 from smclarify.bias.metrics import PRETRAINING_METRICS, POSTTRAINING_METRICS, CI, DPL, KL, KS, DPPL, DI, DCA, DCR, RD
 from smclarify.bias.metrics import common
@@ -1023,3 +1026,18 @@ def label_value_or_threshold_test_cases():
 def test_label_value_or_threshold(function_input, function_output):
     result = label_value_or_threshold(*function_input)
     assert result == function_output.result
+
+
+def test_positive_predicted_index_continuous_multiple_thresholds():
+    predicted_label_data = pd.Series([0, 100, 200, 1000])
+    label_data = pd.Series([1, 150, 500])
+    with pytest.raises(ValueError, match="Only a single threshold is supported for continuous datatypes"):
+        _positive_predicted_index(
+            predicted_label_data, common.DataType.CONTINUOUS, label_data, common.DataType.CONTINUOUS, [100, 150]
+        )
+
+
+def test_positive_label_index_continuous_multiple_thresholds():
+    data = pd.Series([0, 100, 200, 1000])
+    with pytest.raises(ValueError, match="Only a single threshold is supported for continuous datatypes"):
+        _positive_label_index(data, common.DataType.CONTINUOUS, [100, 150])


### PR DESCRIPTION
Add checks for threshold list for continuous data

Also fix some things related to mypy==0.931 update for Python3.8 to pass type checks

_**Testing**_:

- Local `devtool all` passed
- Local `devtool integ_tests` passed
- `devtool all` in analyzer repo passed
- Github actions: https://github.com/spoorn/amazon-sagemaker-clarify/actions/runs/1943277937



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
