### PR TITLE
Add support for multiple threshold intervals for continuous data

### DIFF
--- a/src/smclarify/bias/metrics/constants.py
+++ b/src/smclarify/bias/metrics/constants.py
@@ -3,6 +3,8 @@
 # Licensed under the Amazon Software License  http://aws.amazon.com/asl/
 
 INFINITY = float("inf")
+INFINITY_STR = "inf"
+NEGATIVE_INFINITY_STR = "-inf"
 UNIQUENESS_THRESHOLD: float = 0.05
 
 # FlipTest internal KNN settings

--- a/src/smclarify/bias/metrics/interval.py
+++ b/src/smclarify/bias/metrics/interval.py
@@ -1,0 +1,164 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
+# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+import re
+from typing import List, Optional
+
+from smclarify.bias.metrics import constants
+
+
+class Interval:
+    """Represents a numerical interval with a left bound and right bound"""
+
+    _supported_closed = ["left", "right", "both", "neither"]
+
+    interval_regex_pattern = re.compile(r"^ *[\[\(] *-?[0-9]*\.?[0-9]* *, *-?[0-9]*\.?[0-9]* *[\]\)] *$")
+
+    def __init__(self, left: Optional[float], right: Optional[float], closed: str = "both"):
+        if closed not in self._supported_closed:
+            raise ValueError(f"closed={closed} is not valid.  Must be in {self._supported_closed}")
+        if left and right and left > right:
+            raise ValueError("left bound cannot be greater than right bound")
+        if closed == self._supported_closed[-1] and left and right and left == right:
+            raise ValueError("Interval has exclusive bounds, but left==right")
+        if left is None:
+            self.left = float("-inf")
+        else:
+            self.left = left
+        if right is None:
+            self.right = float("inf")
+        else:
+            self.right = right
+        self.closed = closed
+        self.left_inclusive = True
+        self.right_inclusive = True
+        if closed == "left" or closed == "neither":
+            self.right_inclusive = False
+        if closed == "right" or closed == "neither":
+            self.left_inclusive = False
+
+    def __repr__(self):
+        if self.left_inclusive:
+            left_bound = "["
+        else:
+            left_bound = "("
+        if self.right_inclusive:
+            right_bound = "]"
+        else:
+            right_bound = ")"
+        return left_bound + str(self.left) + ", " + str(self.right) + right_bound
+
+    def __eq__(self, other):
+        if isinstance(other, Interval):
+            return self.__dict__ == other.__dict__
+        return False
+
+    def __contains__(self, item):
+        return self.contains(item)
+
+    def contains(self, item: float) -> bool:
+        if item == self.left and item == self.right:
+            return self.left_inclusive or self.right_inclusive
+        if item == self.left:
+            return self.left_inclusive
+        elif item == self.right:
+            return self.right_inclusive
+        else:
+            return self.left < item < self.right
+
+    @classmethod
+    def from_string(
+        cls, interval: str, min_value: Optional[float] = None, max_value: Optional[float] = None
+    ) -> "Interval":
+        """
+        Generates an Interval from a string representation.
+        The string must fit the regex pattern -> r'^ *[\[\(] *-?[0-9]*\.?[0-9]* *, *-?[0-9]*\.?[0-9]* *[\]\)] *$'
+        Valid examples: "(1, 5]", "[1, 5]", "[1, 5)", "(1, 5)", "(, 5]", "(5, ]", "(-inf, inf]", "[-inf,)"
+
+        :param interval: string representation of an interval
+        :param min_value: Minimum bound for this interval.  Useful for when the minimum bound is not specified in the
+            interval string, but minimum should default to this min_value instead of float(-inf)
+        :param max_value: Maximum bound for this interval.  Similar use to min_value
+        :return: Interval object decoded from the interval string
+        :raise ValueError: If the input is malformed
+        """
+
+        interval = interval.strip()
+        if interval.startswith("["):
+            left_inclusive = True
+        elif interval.startswith("("):
+            left_inclusive = False
+        else:
+            raise ValueError(
+                f"interval={interval} is not valid.  " f'Must start with an interval left bound "[" or "("'
+            )
+        if interval.endswith("]"):
+            right_inclusive = True
+        elif interval.endswith(")"):
+            right_inclusive = False
+        else:
+            raise ValueError(f"interval={interval} is not valid.  " f'Must end with an interval right bound "]" or ")"')
+
+        interval_bounds = [x.strip() for x in interval[1:-1].split(",")]
+        if len(interval_bounds) != 2:
+            raise ValueError(f'interval={interval} is not valid.  Cannot contain more than one comma ","')
+
+        try:
+            left_bounds = interval_bounds[0]
+            if left_bounds == "" or left_bounds == constants.NEGATIVE_INFINITY_STR:
+                left = min_value if min_value else None
+            else:
+                left = cls._validate_interval_number(left_bounds)
+            right_bounds = interval_bounds[1]
+            if right_bounds == "" or right_bounds == constants.INFINITY_STR:
+                right = max_value if max_value else None
+            else:
+                right = cls._validate_interval_number(right_bounds)
+            if left_inclusive and right_inclusive:
+                closed = "both"
+            elif left_inclusive:
+                closed = "left"
+            elif right_inclusive:
+                closed = "right"
+            else:
+                closed = "neither"
+            return cls(left, right, closed)
+        except ValueError as e:
+            raise ValueError(f"interval={interval} is not valid") from e
+
+    @staticmethod
+    def _validate_interval_number(val) -> float:
+        if isinstance(val, float) or isinstance(val, int):
+            return val
+        elif isinstance(val, str):
+            stripped_val = val.strip()
+            if stripped_val.startswith("-"):
+                stripped_val = stripped_val[1:]
+            if stripped_val.isdecimal():
+                return int(val)
+            elif stripped_val.replace(".", "", 1).isdecimal():
+                return float(val)
+        raise ValueError(f"{val} is not a valid interval number")
+
+
+class IntervalArray:
+    """Wraps around a list of intervals"""
+
+    def __init__(self, intervals: List[Interval]):
+        self.intervals = intervals
+
+    def __iter__(self):
+        return iter(self.intervals)
+
+    def contains(self, item: float) -> List[bool]:
+        """
+        Element-wise contains check for each interval
+
+        :param item: item to check if this IntervalArray contains
+        :return: bool list where True is set at the indices where intervals in the list contain the item
+        """
+
+        res = []
+        for interval in self.intervals:
+            res.append(interval.contains(item))
+        return res

--- a/src/smclarify/bias/metrics/pretraining.py
+++ b/src/smclarify/bias/metrics/pretraining.py
@@ -66,8 +66,6 @@ def DPL(feature: pd.Series, sensitive_facet_index: pd.Series, positive_label_ind
     :param positive_label_index: boolean column indicating positive labels
     :return: a float in the interval [-1, +1] indicating bias in the labels.
     """
-    require(sensitive_facet_index.dtype == bool, "sensitive_facet_index must be of type bool")
-    require(positive_label_index.dtype == bool, "positive_label_index must be of type bool")
     return common.DPL(feature, sensitive_facet_index, positive_label_index)
 
 
@@ -140,7 +138,8 @@ def LP_norm(label: pd.Series, sensitive_facet_index: pd.Series, norm_order) -> f
     if len(Pa) == 0 or len(Pd) == 0:
         raise ValueError("No instance of common facet found, dataset may be too small")
     res = np.linalg.norm(Pa - Pd, norm_order)
-    return res
+    # res should only be a single float value, otherwise this metric is incorrect
+    return float(res)
 
 
 @registry.pretraining

--- a/tests/unit/bias/metrics/test_common.py
+++ b/tests/unit/bias/metrics/test_common.py
@@ -76,6 +76,18 @@ def ensure_series_data_type_test_cases():
     function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CATEGORICAL, new_data=data.astype("category"))
     test_cases.append([function_input, function_output])
 
+    # threshold intervals should be continuous
+    data = pd.Series([1, 2, 3])
+    function_input = EnsureSeriesDataTypeInput(data=data, values=["[2,3]"])
+    function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CONTINUOUS, new_data=data)
+    test_cases.append([function_input, function_output])
+
+    # threshold intervals should be continuous
+    data = pd.Series([1, 2, 3])
+    function_input = EnsureSeriesDataTypeInput(data=data, values=["(1,2]", "(2,3]"])
+    function_output = EnsureSeriesDataTypeOutput(data_type=DataType.CONTINUOUS, new_data=data)
+    test_cases.append([function_input, function_output])
+
     return test_cases
 
 

--- a/tests/unit/bias/metrics/test_interval.py
+++ b/tests/unit/bias/metrics/test_interval.py
@@ -1,0 +1,289 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
+# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+from typing import NamedTuple, Optional, Type
+
+import pytest
+
+from smclarify.bias import Interval, IntervalArray
+
+
+class IntervalInitInput(NamedTuple):
+    left: Optional[float]
+    right: Optional[float]
+    str_form: str
+    closed: str = "both"
+    min_value: Optional[float] = None
+    max_value: Optional[float] = None
+
+
+class IntervalInitOutput(NamedTuple):
+    str_rep: str
+
+
+class IntervalError(NamedTuple):
+    error: Type[Exception]
+    message: str
+
+
+def interval_init_happy_test_cases():
+    test_cases = []
+
+    str_form = "[-inf, inf]"
+    function_input = IntervalInitInput(left=None, right=None, str_form=str_form, closed="both")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    str_form = "(-inf, inf)"
+    function_input = IntervalInitInput(left=None, right=None, str_form=str_form, closed="neither")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    str_form = "(-inf, inf]"
+    function_input = IntervalInitInput(left=None, right=None, str_form=str_form, closed="right")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    str_form = "[-inf, inf)"
+    function_input = IntervalInitInput(left=None, right=None, str_form=str_form, closed="left")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    str_form = "[-inf, ]"
+    function_input = IntervalInitInput(left=None, right=None, str_form=str_form, closed="both")
+    function_output = IntervalInitOutput(str_rep="[-inf, inf]")
+    test_cases.append([function_input, function_output])
+
+    str_form = "[, inf]"
+    function_input = IntervalInitInput(left=None, right=None, str_form=str_form, closed="both")
+    function_output = IntervalInitOutput(str_rep="[-inf, inf]")
+    test_cases.append([function_input, function_output])
+
+    str_form = "[, ]"
+    function_input = IntervalInitInput(left=None, right=None, str_form=str_form, closed="both")
+    function_output = IntervalInitOutput(str_rep="[-inf, inf]")
+    test_cases.append([function_input, function_output])
+
+    str_form = "[13, ]"
+    function_input = IntervalInitInput(left=13, right=None, str_form=str_form, closed="both")
+    function_output = IntervalInitOutput(str_rep="[13, inf]")
+    test_cases.append([function_input, function_output])
+
+    str_form = "[, 13]"
+    function_input = IntervalInitInput(left=None, right=13, str_form=str_form, closed="both")
+    function_output = IntervalInitOutput(str_rep="[-inf, 13]")
+    test_cases.append([function_input, function_output])
+
+    str_form = "[-5, 13]"
+    function_input = IntervalInitInput(left=-5, right=13, str_form=str_form, closed="both")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    str_form = "(-5, 13]"
+    function_input = IntervalInitInput(left=-5, right=13, str_form=str_form, closed="right")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    str_form = "[-5, 13)"
+    function_input = IntervalInitInput(left=-5, right=13, str_form=str_form, closed="left")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    str_form = "(-5, 13)"
+    function_input = IntervalInitInput(left=-5, right=13, str_form=str_form, closed="neither")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    str_form = "(13, 13]"
+    function_input = IntervalInitInput(left=13, right=13, str_form=str_form, closed="right")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    str_form = "[13, 13)"
+    function_input = IntervalInitInput(left=13, right=13, str_form=str_form, closed="left")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    str_form = "[13, 13]"
+    function_input = IntervalInitInput(left=13, right=13, str_form=str_form, closed="both")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    str_form = "[13.0, 13.1]"
+    function_input = IntervalInitInput(left=13.0, right=13.1, str_form=str_form, closed="both")
+    function_output = IntervalInitOutput(str_rep=str_form)
+    test_cases.append([function_input, function_output])
+
+    return test_cases
+
+
+def interval_init_error_cases():
+    test_cases = []
+
+    str_form = "(13, 13)"
+    function_input = IntervalInitInput(left=13, right=13, str_form=str_form, closed="neither")
+    expected_error = IntervalError(error=ValueError, message="Interval has exclusive bounds, but left==right")
+    test_cases.append([function_input, expected_error])
+
+    str_form = "(14, 13)"
+    function_input = IntervalInitInput(left=14, right=13, str_form=str_form, closed="neither")
+    expected_error = IntervalError(error=ValueError, message="left bound cannot be greater than right bound")
+    test_cases.append([function_input, expected_error])
+
+    str_form = "(13.001, 13)"
+    function_input = IntervalInitInput(left=13.001, right=13, str_form=str_form, closed="neither")
+    expected_error = IntervalError(error=ValueError, message="left bound cannot be greater than right bound")
+    test_cases.append([function_input, expected_error])
+
+    str_form = "[13, 13]"
+    function_input = IntervalInitInput(left=13, right=13, str_form=str_form, closed="unsupportedasdf!!")
+    expected_error = IntervalError(
+        error=ValueError,
+        message="closed=unsupportedasdf!! is not valid.  " "Must be in \['left', 'right', 'both', 'neither'\]",
+    )
+    test_cases.append([function_input, expected_error])
+
+    return test_cases
+
+
+def interval_from_string_error_cases():
+    test_cases = []
+
+    function_input = "a5,6]"
+    expected_error = IntervalError(
+        error=ValueError,
+        message="interval=a5,6\] is not valid.  " 'Must start with an interval left bound "\[" or "\("',
+    )
+    test_cases.append([function_input, expected_error])
+
+    function_input = "[5,6b"
+    expected_error = IntervalError(
+        error=ValueError, message="interval=\[5,6b is not valid.  " 'Must end with an interval right bound "\]" or "\)"'
+    )
+    test_cases.append([function_input, expected_error])
+
+    function_input = "[5,6,7]"
+    expected_error = IntervalError(
+        error=ValueError, message="interval=\[5,6,7\] is not valid.  " 'Cannot contain more than one comma ","'
+    )
+    test_cases.append([function_input, expected_error])
+
+    function_input = "[a,13]"
+    expected_error = IntervalError(error=ValueError, message="interval=\[a,13\] is not valid")
+    test_cases.append([function_input, expected_error])
+
+    function_input = "[13,b]"
+    expected_error = IntervalError(error=ValueError, message="interval=\[13,b\] is not valid")
+    test_cases.append([function_input, expected_error])
+
+    return test_cases
+
+
+@pytest.mark.parametrize("function_input,function_output", interval_init_happy_test_cases())
+def test_interval_init_happy_cases(function_input, function_output):
+    interval = Interval(function_input.left, function_input.right, function_input.closed)
+
+    if function_input.left is None:
+        assert interval.left == float("-inf")
+        if interval.left_inclusive:
+            assert interval.contains(float("-inf"))
+    else:
+        assert interval.left == function_input.left
+    if function_input.right is None:
+        assert interval.right == float("inf")
+        if interval.right_inclusive:
+            assert interval.contains(float("inf"))
+    else:
+        assert interval.right == function_input.right
+
+    assert interval.closed == function_input.closed
+
+    closed = function_input.closed
+    if closed == "left" or closed == "both":
+        assert interval.contains(interval.left)
+        assert interval.left_inclusive
+    else:
+        assert not interval.left_inclusive
+        if function_input.left and interval.left != interval.right:
+            assert not interval.contains(interval.left)
+        elif not function_input.left:
+            assert not interval.contains(interval.left)
+    if closed == "right" or closed == "both":
+        assert interval.contains(interval.right)
+        assert interval.right_inclusive
+    else:
+        assert not interval.right_inclusive
+        if function_input.right and interval.left != interval.right:
+            assert not interval.contains(interval.right)
+        elif not function_input.right:
+            assert not interval.contains(interval.right)
+    if function_input.left or function_input.right:
+        assert interval.contains((interval.left + interval.right) / 2)
+
+    assert function_output.str_rep == str(interval)
+
+    assert Interval.from_string(function_input.str_form) == interval
+
+
+@pytest.mark.parametrize("function_input,expected_error", interval_init_error_cases())
+def test_interval_init_error_cases(function_input, expected_error):
+    with pytest.raises(expected_error.error, match=expected_error.message):
+        Interval(function_input.left, function_input.right, function_input.closed)
+
+
+@pytest.mark.parametrize("function_input,expected_error", interval_from_string_error_cases())
+def test_interval_from_string_error_cases(function_input, expected_error):
+    with pytest.raises(expected_error.error, match=expected_error.message):
+        Interval.from_string(function_input)
+
+
+def test_interval_from_string_min_and_max_values():
+    interval = Interval.from_string("[-inf, inf]", min_value=-10, max_value=13)
+    assert "[-10, 13]" == str(interval)
+    assert interval.left == -10
+    assert interval.right == 13
+
+
+def test_interval__validate_interval_number():
+    # success cases
+    assert Interval._validate_interval_number(13.0) == 13.0
+    assert Interval._validate_interval_number(13) == 13
+    assert (
+        isinstance(Interval._validate_interval_number("13.0"), float)
+        and Interval._validate_interval_number("13.0") == 13.0
+    )
+    assert isinstance(Interval._validate_interval_number("13"), int) and Interval._validate_interval_number("13") == 13
+    assert (
+        isinstance(Interval._validate_interval_number("-13.0"), float)
+        and Interval._validate_interval_number("-13.0") == -13.0
+    )
+    assert (
+        isinstance(Interval._validate_interval_number("-13"), int) and Interval._validate_interval_number("-13") == -13
+    )
+    assert (
+        isinstance(Interval._validate_interval_number(" -13 "), int)
+        and Interval._validate_interval_number(" -13 ") == -13
+    )
+    # edge cases
+    assert Interval._validate_interval_number(True) == 1
+    assert Interval._validate_interval_number(False) == 0
+
+    # error cases
+    with pytest.raises(ValueError, match="\[1, 2\] is not a valid interval number"):
+        Interval._validate_interval_number([1, 2])
+    with pytest.raises(ValueError, match="13.0.1 is not a valid interval number"):
+        Interval._validate_interval_number("13.0.1")
+    with pytest.raises(ValueError, match="- 13 is not a valid interval number"):
+        Interval._validate_interval_number("- 13")
+
+
+def test_interval_array():
+    interval_array = IntervalArray([Interval.from_string("(5,13]"), Interval.from_string("(-2,6]")])
+    assert interval_array.contains(-1) == [False, True]
+    assert interval_array.contains(6) == [True, True]
+    assert interval_array.contains(13) == [True, False]
+    assert interval_array.contains(10) == [True, False]
+    assert interval_array.contains(0) == [False, True]
+    assert interval_array.contains(-2) == [False, False]
+    assert interval_array.contains(14) == [False, False]
+    assert interval_array.contains(-5) == [False, False]


### PR DESCRIPTION
Add support for multiple threshold intervals for continuous data with full control over bounds via string representations in the existing param for thresholds.

**Testing**:

- `devtool all`
- `devtool integ_tests`
- Updated containers analyzer to use thresholds and verified `devtool all` passed
- Github actions: https://github.com/spoorn/amazon-sagemaker-clarify/actions/runs/1971121051


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
