### PR TITLE
implementations for specificity difference and generalized entropy

### DIFF
--- a/tests/unit/bias/metrics/test_metrics.py
+++ b/tests/unit/bias/metrics/test_metrics.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
 # Licensed under the Amazon Software License  http://aws.amazon.com/asl/
 
-from smclarify.bias.metrics import AD, CDDL, CI, DAR, DCA, DCR, DI, DPL, DRR, FT, JS, KL, LP, RD, TE, KS
+from smclarify.bias.metrics import AD, CDDL, CI, DAR, DCA, DCR, DI, DPL, DRR, FT, JS, KL, LP, RD, TE, KS, SD, GE2
 from smclarify.bias.metrics import metric_one_vs_all
 from smclarify.bias.metrics.constants import INFINITY
 from pytest import approx
@@ -418,6 +418,15 @@ def test_RD():
     assert RD(dfB[0], sensitive_facet_index, dfB_pos_label_idx, dfB_pos_pred_label_idx) == approx(2 / 3)
 
 
+def test_SD():
+    # Binary Facet, Binary Label
+    sensitive_facet_index = dfB[0] == "F"
+    assert SD(dfB[0], sensitive_facet_index, dfB_pos_label_idx, dfB_pos_pred_label_idx) == approx(1 / 6)
+
+    sensitive_facet_index = dfB[0] == "M"
+    assert SD(dfB[0], sensitive_facet_index, dfB_pos_label_idx, dfB_pos_pred_label_idx) == approx(-1 / 6)
+
+
 def test_DRR():
     # Binary Facet, Binary Label
     sensitive_facet_index = dfB[0] == "F"
@@ -484,3 +493,7 @@ def test_FT_small_samples():
     sensitive_facet_index = dfFT[0]
     predicted = pd.Series([1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1])
     assert FT(dfFT, sensitive_facet_index == 1, predicted == 1) == approx(-0.15384615384615385)
+
+
+def test_GE2():
+    assert GE2(dfB_pos_label_idx, dfB_pos_pred_label_idx) == approx(0.24556213017751485)

--- a/tests/unit/bias/test_report.py
+++ b/tests/unit/bias/test_report.py
@@ -403,12 +403,19 @@ def test_report_continuous_data():
                     "value": pytest.approx(0.6666666666666667),
                 },
                 {"description": "Flip Test (FT)", "name": "FT", "value": pytest.approx(-0.23076923076923078)},
-                {"description": "Recall Difference (RD)", "name": "RD", "value": pytest.approx(-1.0)},
+                {
+                    "description": "Generalized Entropy Index with alpha=2. Is half of the coefficient of variation squared.",
+                    "name": "GE2",
+                    "value": 0.07593688362919139,
+                },
+                {"description": "Recall Difference (RD)", "name": "RD", "value": -1.0},
+                {"description": "Specificity Difference (SD)", "name": "SD", "value": 0.1388888888888889},
                 {"description": "Treatment Equality (TE)", "name": "TE", "value": pytest.approx(-0.25)},
             ],
             "value_or_threshold": "(2, 4]",
         }
     ]
+    print(posttraining_report)
     assert posttraining_report == expected_result_1
 
 
@@ -844,7 +851,9 @@ def test_metric_descriptions():
         "DPPL": "Difference in Positive Proportions in Predicted Labels (DPPL)",
         "DRR": "Difference in Rejection Rates (DRR)",
         "FT": "Flip Test (FT)",
+        "GE2": "Generalized Entropy Index with alpha=2. Is half of the coefficient of variation squared.",
         "RD": "Recall Difference (RD)",
+        "SD": "Specificity Difference (SD)",
         "TE": "Treatment Equality (TE)",
     }
     assert posttraining_metric_descriptions == expected_result_2


### PR DESCRIPTION
*Issue #, if available:*
RAI-1485
*Description of changes:*
Implementations for Specificity Difference and Generalized Entropy (only for alpha=2).
Official Documentation: https://arxiv.org/abs/1807.00787
Definition for GE: https://fidelity.github.io/jurity/about_fairness.html#generalized-entropy-index 
`./devtool all` passes
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
