### PR TITLE
Restore imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   rev: v1.1
   hooks:
     - id: autoflake
-      args: ['--in-place', '--expand-star-imports', '--remove-all-unused-imports']
+      args: ['--in-place', '--expand-star-imports']
 
 -   repo: https://github.com/psf/black
     rev: 22.6.0

--- a/src/smclarify/bias/metrics/__init__.py
+++ b/src/smclarify/bias/metrics/__init__.py
@@ -4,6 +4,9 @@ import inspect
 from .posttraining import *
 from .pretraining import *
 
+from . import basic_stats
+from . import pretraining
+from . import posttraining
 from . import registry
 
 PRETRAINING_METRICS = registry.PRETRAINING_METRIC_FUNCTIONS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Will fix the container build in the pipeline. Flake8 had removed some "unused imports" from __init__.py which autoimported some needed functions such as smclarify.bias.metrics.basic_stats.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
