### PR TITLE
fix: integ test values with new bias metrics

### DIFF
--- a/devtool
+++ b/devtool
@@ -41,7 +41,6 @@ lint() {
 }
 
 test_with_coverage() {
-    scripts/run_examples.py
     coverage run -m pytest --pspec tests/unit
     coverage report -m --fail-under=88
 }
@@ -73,6 +72,7 @@ install_package(){
 all() {
     lint
     test_with_coverage
+    integ_tests
     build_package
     docs
 }

--- a/tests/integration/test_bias_metrics.py
+++ b/tests/integration/test_bias_metrics.py
@@ -163,11 +163,12 @@ def test_bias_metrics():
                     "value": pytest.approx(0.06494661921708189),
                 },
                 {"name": "FT", "description": "Flip Test (FT)", "value": pytest.approx(-0.32373271889400923)},
+                {"name": "GE", "description": "Generalized Entropy (GE)", "value": 0.04922014234295094},
                 {"name": "RD", "description": "Recall Difference (RD)", "value": pytest.approx(0.049812030075187974)},
+                {"name": "SD", "description": "Specificity Difference (SD)", "value": 0.13076923076923075},
                 {"name": "TE", "description": "Treatment Equality (TE)", "value": pytest.approx(0.6774193548387097)},
             ],
         }
     ]
-
     assert pre_training_metrics == pre_training_expected_result
     assert post_training_metrics == post_training_expected_result

--- a/tests/integration/test_bias_metrics.py
+++ b/tests/integration/test_bias_metrics.py
@@ -163,9 +163,13 @@ def test_bias_metrics():
                     "value": pytest.approx(0.06494661921708189),
                 },
                 {"name": "FT", "description": "Flip Test (FT)", "value": pytest.approx(-0.32373271889400923)},
-                {"name": "GE", "description": "Generalized Entropy (GE)", "value": 0.04922014234295094},
+                {"name": "GE", "description": "Generalized Entropy (GE)", "value": pytest.approx(0.04922014234295094)},
                 {"name": "RD", "description": "Recall Difference (RD)", "value": pytest.approx(0.049812030075187974)},
-                {"name": "SD", "description": "Specificity Difference (SD)", "value": 0.13076923076923075},
+                {
+                    "name": "SD",
+                    "description": "Specificity Difference (SD)",
+                    "value": pytest.approx(0.13076923076923075),
+                },
                 {"name": "TE", "description": "Treatment Equality (TE)", "value": pytest.approx(0.6774193548387097)},
             ],
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix a test to include values for new bias metrics. Unblocks pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
