### PR TITLE
fix: skip integration tests from devtool all

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,5 @@ cd src/
 ```
 
 For running unit tests, do `pytest --pspec`. If you are using PyCharm, and cannot see the green run button next to the tests, open `Preferences` -> `Tools` -> `Python Integrated tools`, and set default test runner to `pytest`.
+
+For Internal contributors, run ```../devtool integ_tests``` after creating virtualenv with the above steps to run the integration tests.

--- a/devtool
+++ b/devtool
@@ -15,7 +15,6 @@ unit_tests() {
 
 integ_tests() {
     pytest --pspec tests/integration
-    scripts/run_examples.py
 }
 
 lint() {
@@ -41,6 +40,7 @@ lint() {
 }
 
 test_with_coverage() {
+    scripts/run_examples.py
     coverage run -m pytest --pspec tests/unit
     coverage report -m --fail-under=88
 }
@@ -72,7 +72,6 @@ install_package(){
 all() {
     lint
     test_with_coverage
-    integ_tests
     build_package
     docs
 }


### PR DESCRIPTION
*Issue #, if available:*
Integration tests can't be run by external contributors without access to s3 datasets hosted in internal account.

*Description of changes:*
1. skip running integ_tests as part of ```./devtool all```
2. revert the run_examples as a part of test_with_coverage to include it with github actions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
