### PR TITLE
add basic stat metric, and model performance report

### DIFF
--- a/src/smclarify/bias/metrics/basic_stats.py
+++ b/src/smclarify/bias/metrics/basic_stats.py
@@ -188,8 +188,8 @@ def multicategory_confusion_matrix(
     :return: Matrix JSON where rows refer to true labels, and columns refer to predicted labels
     """
     # Handle differing pd.Series dtypes
-    unique_label_values = set(label_series.unique())
-    unique_label_values.update(predicted_label_series.unique())
+    unique_label_values = list(label_series.unique())
+    unique_label_values.sort()
     if label_series.dtype.name != predicted_label_series.dtype.name:
         try:
             predicted_label_series = predicted_label_series.astype(label_series.dtype)

--- a/src/smclarify/bias/metrics/basic_stats.py
+++ b/src/smclarify/bias/metrics/basic_stats.py
@@ -1,8 +1,10 @@
 import logging
-from typing import List
-
+from typing import List, Optional, Dict
+from smclarify.bias.metrics.common import divide, binary_confusion_matrix
+from sklearn.metrics import confusion_matrix as sklearn_confusion_matrix
+from pandas.api.types import CategoricalDtype
 import pandas as pd
-from .common import divide
+from functional import seq
 
 log = logging.getLogger(__name__)
 
@@ -20,15 +22,9 @@ def confusion_matrix(
     :param sensitive_facet_index: boolean column indicating sensitive group
     :param positive_label_index: boolean column indicating positive labels
     :param positive_predicted_label_index: boolean column indicating positive predicted labels
-    :return list of fractions of true positives, false positives, false negatives, true negatives
+    :return fractions of true positives, false positives, true negatives, false negatives
     """
-    TP_d = len(feature[positive_label_index & positive_predicted_label_index & sensitive_facet_index])
-    FN_d = len(feature[positive_label_index & (~positive_predicted_label_index) & sensitive_facet_index])
-
-    TN_d = len(feature[(~positive_label_index) & (~positive_predicted_label_index) & sensitive_facet_index])
-    FP_d = len(feature[(~positive_label_index) & positive_predicted_label_index & sensitive_facet_index])
-    size = len(feature[sensitive_facet_index])
-    return [divide(TP_d, size), divide(FP_d, size), divide(FN_d, size), divide(TN_d, size)]
+    return binary_confusion_matrix(feature[sensitive_facet_index], positive_label_index, positive_predicted_label_index)
 
 
 def proportion(sensitive_facet_index: pd.Series) -> float:
@@ -39,3 +35,191 @@ def proportion(sensitive_facet_index: pd.Series) -> float:
     :return: the fraction of examples in the sensitive facet.
     """
     return sum(sensitive_facet_index) / len(sensitive_facet_index)
+
+
+def observed_label_distribution(
+    feature: pd.DataFrame, sensitive_facet_index: pd.Series, positive_label_index: pd.Series
+) -> List[float]:
+    r"""
+    Distribution of observed label outcomes for sensitive facet
+
+    :param feature: input feature
+    :param sensitive_facet_index: boolean column indicating sensitive group
+    :param positive_label_index: boolean column indicating positive labels
+    :return: List of Proportion of positive and negative label outcomes
+    """
+    pos = len(feature[sensitive_facet_index & positive_label_index])
+    n = len(feature[sensitive_facet_index])
+    proportion_pos = divide(pos, n)
+    return [proportion_pos, 1 - proportion_pos]
+
+
+# Model Performance Metrics
+def accuracy(TP: int, FP: int, TN: int, FN: int) -> float:
+    r"""
+    Proportion of inputs assigned the correct predicted label by the model.
+
+    :param: TP Counts of labels which were correctly predicted positive
+    :param: FP Counts of labels which were incorrectly predicted positive
+    :param: TN Counts of labels which were correctly predicted negative
+    :param: FN Counts of labels which were incorrectly predicted negative
+    :return: Proportion of inputs assigned the correct predicted label by the model.
+    """
+    return divide(TN + TP, TN + FP + FN + TP)
+
+
+def PPL(TP: int, FP: int, TN: int, FN: int) -> float:
+    r"""
+    Proportion of input assigned in positive predicted label.
+
+    :param: TP: Counts of labels which were correctly predicted positive
+    :param: FP: Counts of labels which were incorrectly predicted positive
+    :param: TN: Counts of labels which were correctly predicted negative
+    :param: FN: Counts of labels which were incorrectly predicted negative
+    :return: Proportion of inputs assigned the positive predicted label.
+    """
+    return divide(TP + FP, TN + FP + FN + TP)
+
+
+def PNL(TP: int, FP: int, TN: int, FN: int) -> float:
+    r"""
+    Proportion of input assigned the negative predicted label.
+
+    :param: TP: Counts of labels which were correctly predicted positive
+    :param: FP: Counts of labels which were incorrectly predicted positive
+    :param: TN: Counts of labels which were correctly predicted negative
+    :param: FN: Counts of labels which were incorrectly predicted negative
+    :return: Proportion of inputs assigned the negative predicted label.
+    """
+    return divide(TN + FN, TN + FP + FN + TP)
+
+
+def recall(TP: int, FN: int) -> float:
+    r"""
+    Proportion of inputs with positive observed label correctly assigned the positive predicted label.
+
+    :param: TP Counts of labels which were correctly predicted positive
+    :param: FN Counts of labels which were incorrectly predicted negative
+    :return: Proportion of inputs with positive observed label correctly assigned the positive predicted label.
+    """
+    return divide(TP, TP + FN)
+
+
+def specificity(TN: int, FP: int) -> float:
+    r"""
+    Proportion of inputs with negative observed label correctly assigned the negative predicted label.
+
+    :param: FP Counts of labels which were incorrectly predicted positive
+    :param: TN Counts of labels which were correctly predicted negative
+    :return: Proportion of inputs with negative observed label correctly assigned the negative predicted label.
+    """
+    return divide(TN, TN + FP)
+
+
+def precision(TP: int, FP: int) -> float:
+    r"""
+    Proportion of inputs with positive predicted label that actually have a positive observed label.
+
+    :param: TP Counts of labels which were correctly predicted positive
+    :param: FP Counts of labels which were incorrectly predicted positive
+    :return: Proportion of inputs with positive predicted label that actually have a positive observed label.
+    """
+    return divide(TP, FP + TP)
+
+
+def rejection_rate(TN: int, FN: int) -> float:
+    r"""
+    Proportion of inputs with negative predicted label that actually have a negative observed label.
+
+    :param: TN Counts of labels which were correctly predicted negative
+    :param: FN Counts of labels which were incorrectly predicted negative
+    :return: Proportion of inputs with negative predicted label that actually have a negative observed label.
+    """
+    return divide(TN, TN + FN)
+
+
+def conditional_acceptance(TP: int, FP: int, FN: int) -> float:
+    r"""
+    Ratio between the positive observed labels and positive predicted labels.
+
+    :param: TP Counts of labels which were correctly predicted positive
+    :param: FP Counts of labels which were incorrectly predicted positive
+    :param: FN Counts of labels which were incorrectly predicted negative
+    :return: Ratio between the positive observed labels and positive predicted labels.
+    """
+    return divide(FN + TP, FP + TP)
+
+
+def conditional_rejection(FP: int, TN: int, FN: int) -> float:
+    r"""
+    Ratio between the negative observed labels and negative predicted labels.
+
+    :param: FP Counts of labels which were incorrectly predicted positive
+    :param: TN Counts of labels which were correctly predicted negative
+    :param: FN Counts of labels which were incorrectly predicted negative
+    :return: Ratio between the negative observed labels and negative predicted labels.
+    """
+    return divide(TN + FP, TN + FN)
+
+
+def f1_score(TP: int, FP: int, FN: int) -> float:
+    r"""
+    Harmonic mean of precision and recall.
+
+    :param: TP Counts of labels which were correctly predicted positive
+    :param: FP Counts of labels which were incorrectly predicted positive
+    :param: FN Counts of labels which were incorrectly predicted negative
+    :return: Harmonic mean of precision and recall.
+    """
+    precision_score = precision(TP, FP)
+    recall_score = recall(TP, FN)
+    return 2 * divide(precision_score * recall_score, precision_score + recall_score)
+
+
+# Model Performance Metrics
+def multicategory_confusion_matrix(
+    label_series: pd.Series, predicted_label_series: pd.Series
+) -> Optional[Dict[str, Dict]]:
+    """
+    Confusion Matrix for categorical label cases.
+    :param label_series: Label Data Series
+    :param predicted_label_series: Predicted Label Data Series
+    :param unique_label_values: List of unique label values computed from the set of true and predicted labels
+    :return: Matrix JSON where rows refer to true labels, and columns refer to predicted labels
+    """
+    # Handle differing pd.Series dtypes
+    unique_label_values = set(label_series.unique())
+    unique_label_values.update(predicted_label_series.unique())
+    if label_series.dtype.name != predicted_label_series.dtype.name:
+        try:
+            predicted_label_series = predicted_label_series.astype(label_series.dtype)
+        except:
+            log.warning(
+                "Predicted Label Series could not be cast as Label Series type. Multicategory Confusion Matrix won't be computed"
+            )
+            return None
+    # Handle CategoricalDtype difference (see test/integration/test_bias_metrics)
+    if label_series.dtype == "category" and label_series.dtype != predicted_label_series.dtype:
+        try:
+            pred_label_category = predicted_label_series.dtype.categories.astype(label_series.dtype.categories.dtype)
+            category_obj = CategoricalDtype(pred_label_category, label_series.dtype.ordered)
+            predicted_label_series = predicted_label_series.astype(category_obj)
+        except:
+            log.warning(
+                "Predicted Label Series could not be cast as Label Series type. Multicategory Confusion Matrix won't be computed"
+            )
+            return None
+    confusion_matrix_array = sklearn_confusion_matrix(
+        label_series, predicted_label_series, labels=list(unique_label_values)
+    )
+    assert confusion_matrix_array.shape == (
+        len(unique_label_values),
+        len(unique_label_values),
+    )
+    matrix_json = {}
+    unique_label_strings = [str(val) for val in unique_label_values]
+    for index, val in enumerate(unique_label_strings):
+        confusion_matrix_floats = [float(cfn_val) for cfn_val in confusion_matrix_array[index]]
+        matrix_json[val] = seq(unique_label_strings).zip(confusion_matrix_floats).dict()
+
+    return matrix_json

--- a/src/smclarify/bias/metrics/common.py
+++ b/src/smclarify/bias/metrics/common.py
@@ -49,6 +49,19 @@ def metric_description(metric: Callable[..., float]) -> str:
     return metric.__doc__.lstrip().split("\n")[0]  # type: ignore
 
 
+def binary_confusion_matrix(
+    feature: pd.Series, positive_label_index: pd.Series, positive_predicted_label_index: pd.Series
+) -> List[int]:
+    TP = len(feature[positive_label_index & positive_predicted_label_index])
+    TN = len(feature[~positive_label_index & (~positive_predicted_label_index)])
+
+    FP = len(feature[(~positive_label_index) & positive_predicted_label_index])
+    FN = len(feature[(positive_label_index) & (~positive_predicted_label_index)])
+
+    n = len(feature)
+    return [divide(TP, n), divide(FP, n), divide(FN, n), divide(TN, n)]
+
+
 def DPL(feature: pd.Series, sensitive_facet_index: pd.Series, positive_label_index: pd.Series) -> float:
     require(sensitive_facet_index.dtype == bool, "sensitive_facet_index must be of type bool")
     require(positive_label_index.dtype == bool, "label_index must be of type bool")
@@ -73,7 +86,7 @@ def CDD(
     :param feature: input feature
     :param sensitive_facet_index: boolean column indicating sensitive group
     :param label_index: boolean column indicating positive labels or predicted labels
-    :param group_variable: categorical column indicating subgroups each point belongs to
+    :param group_variable: categorical column indicating subgroups each point beints to
     :return: the weighted average of demographic disparity on all subgroups
     """
     if group_variable is None or group_variable.empty:

--- a/src/smclarify/bias/report.py
+++ b/src/smclarify/bias/report.py
@@ -448,9 +448,14 @@ def model_performance_report(df: pd.DataFrame, label_column: LabelColumn, predic
     )
     binary_confusion_matrix = common.binary_confusion_matrix(df, positive_label_index, positive_predicted_label_index)
     if label_data_type == common.DataType.CATEGORICAL:
-        multicategory_confusion_matrix = basic_stats.multicategory_confusion_matrix(
-            label_data_series, predicted_label_data_series
-        )
+        try:
+            multicategory_confusion_matrix = basic_stats.multicategory_confusion_matrix(
+                label_data_series, predicted_label_data_series
+            )
+        except Exception as e:
+            multicategory_confusion_matrix = {"error": str(e)}
+            logger.warning("Multicategory Confusion Matrix failed to compute due to: %s", e)
+
         return ModelPerformanceReport(
             label_column.name, perf_metrics, binary_confusion_matrix, confusion_matrix=multicategory_confusion_matrix
         ).toJson()

--- a/src/smclarify/bias/report.py
+++ b/src/smclarify/bias/report.py
@@ -453,7 +453,7 @@ def model_performance_report(df: pd.DataFrame, label_column: LabelColumn, predic
                 label_data_series, predicted_label_data_series
             )
         except Exception as e:
-            multicategory_confusion_matrix = {"error": str(e)}
+            multicategory_confusion_matrix = {"error": {str(e): 0.0}}
             logger.warning("Multicategory Confusion Matrix failed to compute due to: %s", e)
 
         return ModelPerformanceReport(

--- a/tests/unit/bias/metrics/test_basic_stats.py
+++ b/tests/unit/bias/metrics/test_basic_stats.py
@@ -88,8 +88,52 @@ def test_multicategorical_confusion_matrix():
     # Confusion matrix will be of shape (len(unique_label_values), len(unique_label_values))
     label_series = pd.Series([1])
     predicted_label_series = pd.Series([2])
-    expected_value = {
-        "1": {"1": 0, "2": 1},
-        "2": {"1": 0, "2": 0},
-    }
+    expected_value = {"1": {"1": 0.0}}
     assert basic_stats.multicategory_confusion_matrix(label_series, predicted_label_series) == expected_value
+
+    # Strings
+    df = pd.DataFrame(
+        [
+            ("a", "white", 1, "red"),
+            ("b", "white", 1, "blue"),
+            ("b", "blue", 1, "blue"),
+            ("b", "blue", 0, "red"),
+            ("a", "green", 1, "white"),
+            ("b", "white", 1, "white"),
+            ("b", "white", 1, "green"),
+            ("b", "white", 0, "white"),
+        ]
+    )
+    df.columns = ["x", "y", "z", "yhat"]
+
+    expected_value = {
+        "blue": {"blue": 1.0, "green": 0.0, "white": 0.0},
+        "green": {"blue": 0.0, "green": 0.0, "white": 1.0},
+        "white": {"blue": 1.0, "green": 1.0, "white": 2.0},
+    }
+
+    assert basic_stats.multicategory_confusion_matrix(df["y"], df["yhat"]) == expected_value
+
+    df = pd.DataFrame(
+        [
+            ("a", 1, 1, 1),
+            ("b", 1, 1, 0),
+            ("b", 0, 1, 0),
+            ("b", 0, 0, 1),
+            ("a", 2, 1, 3),
+            ("b", 3, 1, 3),
+            ("b", 3, 1, 2),
+            ("b", 1, 0, 3),
+        ]
+    )
+
+    df.columns = ["x", "y", "z", "yhat"]
+
+    expected_value = {
+        "0": {"0": 1.0, "1": 1.0, "2": 0.0, "3": 0.0},
+        "1": {"0": 1.0, "1": 1.0, "2": 0.0, "3": 1.0},
+        "2": {"0": 0.0, "1": 0.0, "2": 0.0, "3": 1.0},
+        "3": {"0": 0.0, "1": 0.0, "2": 1.0, "3": 1.0},
+    }
+
+    basic_stats.multicategory_confusion_matrix(df["y"], df["yhat"]) == expected_value

--- a/tests/unit/bias/metrics/test_basic_stats.py
+++ b/tests/unit/bias/metrics/test_basic_stats.py
@@ -3,7 +3,7 @@ from smclarify.bias.metrics import basic_stats
 from .test_metrics import dfBinary
 
 from pytest import approx
-
+import pandas as pd
 
 (dfB, dfB_label, dfB_pos_label_idx, dfB_pred_label, dfB_pos_pred_label_idx) = dfBinary()
 
@@ -35,3 +35,61 @@ def test_confusion_matrix():
     assert [TP, FP, FN, TN] == basic_stats.confusion_matrix(
         dfB[0], sensitive_facet_index, dfB_pos_label_idx, dfB_pos_pred_label_idx
     )
+
+
+def test_observed_label_distribution():
+    sensitive_facet_index = dfB[0] == "F"
+    label_dist = [approx(3 / 7.0), approx(4 / 7.0)]
+    assert label_dist == basic_stats.observed_label_distribution(dfB[0], sensitive_facet_index, dfB_pos_label_idx)
+
+    sensitive_facet_index = dfB[0] == "M"
+    label_dist = [approx(2 / 5.0), approx(3 / 5.0)]
+    assert label_dist == basic_stats.observed_label_distribution(dfB[0], sensitive_facet_index, dfB_pos_label_idx)
+
+
+def test_performance_metrics():
+    TP = 2
+    TN = 2
+    FP = 1
+    FN = 0
+
+    result = [
+        basic_stats.accuracy(TP, FP, TN, FN),
+        basic_stats.PPL(TP, FP, TN, FN),
+        basic_stats.PNL(TP, FP, TN, FN),
+        basic_stats.recall(TP, FN),
+        basic_stats.specificity(TN, FP),
+        basic_stats.precision(TP, FP),
+        basic_stats.rejection_rate(TN, FN),
+        basic_stats.conditional_acceptance(TP, FP, FN),
+        basic_stats.conditional_rejection(FP, TN, FN),
+        basic_stats.f1_score(TP, FP, FN),
+    ]
+    expected = [
+        approx(4 / 5.0),
+        approx(3 / 5.0),
+        approx(2 / 5.0),
+        approx(2 / 2.0),
+        approx(2 / 3.0),
+        approx(2 / 3.0),
+        approx(2 / 2.0),
+        approx(2 / 3.0),
+        approx(3 / 2.0),
+        4 / 5.0,
+    ]
+
+    assert expected == result
+
+
+def test_multicategorical_confusion_matrix():
+    expected_value = {"0": {"0": 3, "1": 4}, "1": {"0": 3, "1": 2}}
+    assert basic_stats.multicategory_confusion_matrix(dfB_label, dfB_pred_label) == expected_value
+
+    # Confusion matrix will be of shape (len(unique_label_values), len(unique_label_values))
+    label_series = pd.Series([1])
+    predicted_label_series = pd.Series([2])
+    expected_value = {
+        "1": {"1": 0, "2": 1},
+        "2": {"1": 0, "2": 0},
+    }
+    assert basic_stats.multicategory_confusion_matrix(label_series, predicted_label_series) == expected_value

--- a/tests/unit/bias/test_report.py
+++ b/tests/unit/bias/test_report.py
@@ -9,6 +9,7 @@ from smclarify.bias.report import (
     ProblemType,
     problem_type,
     bias_basic_stats,
+    model_performance_report,
     bias_report,
     FacetColumn,
     LabelColumn,
@@ -1037,7 +1038,12 @@ def test_bias_basic_stats():
                     "name": "proportion",
                     "description": "Proportion of examples in sensitive facet.",
                     "value": pytest.approx(0.25),
-                }
+                },
+                {
+                    "name": "observed_label_distribution",
+                    "description": "Distribution of observed label outcomes for sensitive facet",
+                    "value": [pytest.approx(1.0), pytest.approx(0.0)],
+                },
             ],
         },
         {
@@ -1047,7 +1053,12 @@ def test_bias_basic_stats():
                     "name": "proportion",
                     "description": "Proportion of examples in sensitive facet.",
                     "value": pytest.approx(0.75),
-                }
+                },
+                {
+                    "name": "observed_label_distribution",
+                    "description": "Distribution of observed label outcomes for sensitive facet",
+                    "value": [pytest.approx(1 / 3.0), pytest.approx(2 / 3.0)],
+                },
             ],
         },
     ]
@@ -1072,6 +1083,11 @@ def test_bias_basic_stats():
                     "value": pytest.approx(0.25),
                 },
                 {
+                    "name": "observed_label_distribution",
+                    "description": "Distribution of observed label outcomes for sensitive facet",
+                    "value": [pytest.approx(1.0), pytest.approx(0.0)],
+                },
+                {
                     "name": "confusion_matrix",
                     "description": "Fractions of TP, FP, FN, TN.",
                     "value": [pytest.approx(1.0), pytest.approx(0.0), pytest.approx(0.0), pytest.approx(0.0)],
@@ -1087,6 +1103,11 @@ def test_bias_basic_stats():
                     "value": pytest.approx(0.75),
                 },
                 {
+                    "name": "observed_label_distribution",
+                    "description": "Distribution of observed label outcomes for sensitive facet",
+                    "value": [pytest.approx(1 / 3.0), pytest.approx(2 / 3.0)],
+                },
+                {
                     "name": "confusion_matrix",
                     "description": "Fractions of TP, FP, FN, TN.",
                     "value": [
@@ -1100,6 +1121,178 @@ def test_bias_basic_stats():
         },
     ]
     assert expected_results == results
+
+
+def test_model_performance_categorical():
+    df_cat = pd.DataFrame(
+        [["a", "p", 1, 1, "q"], ["b", "p", 1, 0, "q"], ["b", "q", 1, 0, "q"], ["b", "q", 0, 1, "p"]],
+        columns=["x", "y_cat", "z", "yhat", "yhat_cat"],
+    )
+    result = model_performance_report(
+        df=df_cat,
+        label_column=LabelColumn("y_cat", df_cat["y_cat"], ["p"]),
+        predicted_label_column=LabelColumn("yhat_cat", df_cat["yhat_cat"], ["p"]),
+    )
+
+    expected_result = {
+        "label": "y_cat",
+        "model_performance_metrics": [
+            {
+                "name": "Accuracy",
+                "description": "Proportion of inputs assigned the correct predicted label by the model.",
+                "value": pytest.approx(1 / 4.0),
+            },
+            {
+                "name": "Proportion of Positive Predictions in Labels",
+                "description": "Proportion of input assigned in positive predicted label.",
+                "value": pytest.approx(1 / 4.0),
+            },
+            {
+                "name": "Proportion of Negative Predictions in Labels",
+                "description": "Proportion of input assigned the negative predicted label.",
+                "value": pytest.approx(3 / 4.0),
+            },
+            {
+                "name": "True Positive Rate / Recall",
+                "description": "Proportion of inputs with positive observed label correctly assigned the positive predicted label.",
+                "value": pytest.approx(0.0),
+            },
+            {
+                "name": "True Negative Rate / Specificity",
+                "description": "Proportion of inputs with negative observed label correctly assigned the negative predicted label.",
+                "value": pytest.approx(2 / 4.0),
+            },
+            {
+                "name": "Acceptance Rate / Precision",
+                "description": "Proportion of inputs with positive predicted label that actually have a positive observed label.",
+                "value": pytest.approx(0.0),
+            },
+            {
+                "name": "Rejection Rate",
+                "description": "Proportion of inputs with negative predicted label that actually have a negative observed label.",
+                "value": pytest.approx(1 / 3.0),
+            },
+            {
+                "name": "Conditional Acceptance",
+                "description": "Ratio between the positive observed labels and positive predicted labels.",
+                "value": pytest.approx(2.0),
+            },
+            {
+                "name": "Conditional Rejection",
+                "description": "Ratio between the negative observed labels and negative predicted labels.",
+                "value": pytest.approx(2 / 3.0),
+            },
+            {"name": "F1 Score", "description": "Harmonic mean of precision and recall.", "value": pytest.approx(0.0)},
+        ],
+        "binary_confusion_matrix": [pytest.approx(0.0), pytest.approx(0.25), pytest.approx(0.5), pytest.approx(0.25)],
+        "confusion_matrix": {
+            "p": {"p": pytest.approx(0.0), "q": pytest.approx(2.0)},
+            "q": {"p": pytest.approx(1.0), "q": pytest.approx(1.0)},
+        },
+    }
+    assert expected_result == result
+
+
+def test_model_performance_continuous():
+    df_cont = pd.DataFrame(
+        [
+            [0, 0.0, 0, 0, True, 1, 1, 11],  # 11 is the highest among y and yhat
+            [3, 0.5, 0, 0, True, 0, 1, 6],
+            [3, 2, 1, 0, True, 0, 1, 6.6],
+            [0, 3, 0, 0, False, 1, 1, 0.3],
+            [4, 2.2, 0, 1, True, 0, 1, 6],
+            [0, 0.1, 1, 0, True, 1, 1, 6],
+            [3, 0, 0, 0, True, 1, 1, 6],
+            [3, 6, 0, 0, True, 1, 1, 6],
+            [0, 0, 1, 0, True, 1, 1, 6],
+            [3, 0, 1, 1, True, 1, 0, 6],
+            [4, 0, 0, 0, True, 1, 0, 6],
+            [3, 0, 1, 0, True, 1, 1, 6],
+            [3, 0, 0, 0, False, 1, 1, 0],
+            [0, 0, 0, 0, True, 1, 1, 6.2],
+            [0, 0, 1, 0, True, 0, 1, 6.6],
+            [0, 0, 1, 0, True, 1, 1, 6.6],
+            [0, 7, 0, 1, False, 0, 1, 0.1],
+            [3, 0, 0, 0, False, 1, 1, 2],
+            [0, 0, 1, 0, False, 1, 1, 8],
+            [3, 0, 0, 0, True, 1, 0, 9],
+            [3, 0, 1, 0, False, 1, 1, 0.1],
+            [0, 8, 0, 0, False, 1, 1, 2.2],
+            [3, 0, 1, 0, True, 0, 1, 10],
+            [0, 0, 0, 1, True, 1, 0, 9],
+        ],
+        columns=["x", "y", "z", "a", "b", "c", "d", "yhat"],
+    )
+
+    result = model_performance_report(
+        df=df_cont,
+        label_column=LabelColumn("y", df_cont["y"], [5]),
+        predicted_label_column=LabelColumn("yhat", df_cont["yhat"], [5]),
+    )
+    # No multicategory confusion matrix
+
+    expected_result = {
+        "label": "y",
+        "model_performance_metrics": [
+            {
+                "name": "Accuracy",
+                "description": "Proportion of inputs assigned the correct predicted label by the model.",
+                "value": pytest.approx(5 / 24),
+            },
+            {
+                "name": "Proportion of Positive Predictions in Labels",
+                "description": "Proportion of input assigned in positive predicted label.",
+                "value": pytest.approx(0.75),
+            },
+            {
+                "name": "Proportion of Negative Predictions in Labels",
+                "description": "Proportion of input assigned the negative predicted label.",
+                "value": pytest.approx(0.25),
+            },
+            {
+                "name": "True Positive Rate / Recall",
+                "description": "Proportion of inputs with positive observed label correctly assigned the positive predicted label.",
+                "value": pytest.approx(1 / 3),
+            },
+            {
+                "name": "True Negative Rate / Specificity",
+                "description": "Proportion of inputs with negative observed label correctly assigned the negative predicted label.",
+                "value": pytest.approx(4 / 21),
+            },
+            {
+                "name": "Acceptance Rate / Precision",
+                "description": "Proportion of inputs with positive predicted label that actually have a positive observed label.",
+                "value": pytest.approx(1 / 18),
+            },
+            {
+                "name": "Rejection Rate",
+                "description": "Proportion of inputs with negative predicted label that actually have a negative observed label.",
+                "value": pytest.approx(2 / 3.0),
+            },
+            {
+                "name": "Conditional Acceptance",
+                "description": "Ratio between the positive observed labels and positive predicted labels.",
+                "value": pytest.approx(1 / 6),
+            },
+            {
+                "name": "Conditional Rejection",
+                "description": "Ratio between the negative observed labels and negative predicted labels.",
+                "value": pytest.approx(3.5),
+            },
+            {
+                "name": "F1 Score",
+                "description": "Harmonic mean of precision and recall.",
+                "value": pytest.approx(2 / 21),
+            },
+        ],
+        "binary_confusion_matrix": [
+            pytest.approx(1 / 24),
+            pytest.approx(17 / 24),
+            pytest.approx(1 / 12),
+            pytest.approx(1 / 6),
+        ],
+    }
+    assert expected_result == result
 
 
 class LabelValueOrThresholdFunctionInput(NamedTuple):


### PR DESCRIPTION
*Issue #, if available:*
https://sim.amazon.com/issues/RAI-2708
*Description of changes:*
Implements new metric for basicbiasstats and creates a ModelPerformanceReport for dataset level metrics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
