### PR TITLE
fix: update license to Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,96 +1,175 @@
-Amazon Software License 1.0
 
-This Amazon Software License ("License") governs your use, reproduction, and
-distribution of the accompanying software as specified below.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-1. Definitions
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-  "Licensor" means any person or entity that distributes its Work.
+   1. Definitions.
 
-  "Software" means the original work of authorship made available under this
-  License.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-  "Work" means the Software and any additions to or derivative works of the
-  Software that are made available under this License.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-  The terms "reproduce," "reproduction," "derivative works," and
-  "distribution" have the meaning as provided under U.S. copyright law;
-  provided, however, that for the purposes of this License, derivative works
-  shall not include works that remain separable from, or merely link (or bind
-  by name) to the interfaces of, the Work.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-  Works, including the Software, are "made available" under this License by
-  including in or with the Work either (a) a copyright notice referencing the
-  applicability of this License to the Work, or (b) a copy of this License.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-2. License Grants
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-  2.1 Copyright Grant. Subject to the terms and conditions of this License,
-  each Licensor grants to you a perpetual, worldwide, non-exclusive,
-  royalty-free, copyright license to reproduce, prepare derivative works of,
-  publicly display, publicly perform, sublicense and distribute its Work and
-  any resulting derivative works in any form.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-  2.2 Patent Grant. Subject to the terms and conditions of this License, each
-  Licensor grants to you a perpetual, worldwide, non-exclusive, royalty-free
-  patent license to make, have made, use, sell, offer for sale, import, and
-  otherwise transfer its Work, in whole or in part. The foregoing license
-  applies only to the patent claims licensable by Licensor that would be
-  infringed by Licensor's Work (or portion thereof) individually and
-  excluding any combinations with any other materials or technology.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-3. Limitations
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-  3.1 Redistribution. You may reproduce or distribute the Work only if
-  (a) you do so under this License, (b) you include a complete copy of this
-  License with your distribution, and (c) you retain without modification
-  any copyright, patent, trademark, or attribution notices that are present
-  in the Work.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-  3.2 Derivative Works. You may specify that additional or different terms
-  apply to the use, reproduction, and distribution of your derivative works
-  of the Work ("Your Terms") only if (a) Your Terms provide that the use
-  limitation in Section 3.3 applies to your derivative works, and (b) you
-  identify the specific derivative works that are subject to Your Terms.
-  Notwithstanding Your Terms, this License (including the redistribution
-  requirements in Section 3.1) will continue to apply to the Work itself.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-  3.3 Use Limitation. The Work and any derivative works thereof only may be
-  used or intended for use with the web services, computing platforms or
-  applications provided by Amazon.com, Inc. or its affiliates, including
-  Amazon Web Services, Inc.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-  3.4 Patent Claims. If you bring or threaten to bring a patent claim against
-  any Licensor (including any claim, cross-claim or counterclaim in a
-  lawsuit) to enforce any patents that you allege are infringed by any Work,
-  then your rights under this License from such Licensor (including the
-  grants in Sections 2.1 and 2.2) will terminate immediately.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-  3.5 Trademarks. This License does not grant any rights to use any
-  Licensor's or its affiliates' names, logos, or trademarks, except as
-  necessary to reproduce the notices described in this License.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-  3.6 Termination. If you violate any term of this License, then your rights
-  under this License (including the grants in Sections 2.1 and 2.2) will
-  terminate immediately.
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-4. Disclaimer of Warranty.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-  THE WORK IS PROVIDED "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-  EITHER EXPRESS OR IMPLIED, INCLUDING WARRANTIES OR CONDITIONS OF
-  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE OR
-  NON-INFRINGEMENT. YOU BEAR THE RISK OF UNDERTAKING ANY ACTIVITIES UNDER
-  THIS LICENSE. SOME STATES' CONSUMER LAWS DO NOT ALLOW EXCLUSION OF AN
-  IMPLIED WARRANTY, SO THIS DISCLAIMER MAY NOT APPLY TO YOU.
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-5. Limitation of Liability.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-  EXCEPT AS PROHIBITED BY APPLICABLE LAW, IN NO EVENT AND UNDER NO LEGAL
-  THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE
-  SHALL ANY LICENSOR BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY DIRECT,
-  INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR
-  RELATED TO THIS LICENSE, THE USE OR INABILITY TO USE THE WORK (INCLUDING
-  BUT NOT LIMITED TO LOSS OF GOODWILL, BUSINESS INTERRUPTION, LOST PROFITS
-  OR DATA, COMPUTER FAILURE OR MALFUNCTION, OR ANY OTHER COMM ERCIAL DAMAGES
-  OR LOSSES), EVEN IF THE LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF
-  SUCH DAMAGES.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 """
 Runs examples, failing if they have errors using jupyter-nbconvert

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 import os
 from setuptools import find_packages, setup
 

--- a/src/smclarify/bias/metrics/common.py
+++ b/src/smclarify/bias/metrics/common.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 import logging
 from enum import Enum

--- a/src/smclarify/bias/metrics/constants.py
+++ b/src/smclarify/bias/metrics/constants.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 INFINITY = float("inf")
 UNIQUENESS_THRESHOLD: float = 0.05

--- a/src/smclarify/bias/metrics/posttraining.py
+++ b/src/smclarify/bias/metrics/posttraining.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 """
 Post training metrics

--- a/src/smclarify/bias/metrics/pretraining.py
+++ b/src/smclarify/bias/metrics/pretraining.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 """
 Pre-training metrics

--- a/src/smclarify/bias/metrics/registry.py
+++ b/src/smclarify/bias/metrics/registry.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 """
 A module to register metric functions by decorators. Not supposed to be used outside of the package.

--- a/src/smclarify/bias/report.py
+++ b/src/smclarify/bias/report.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 """Bias detection in datasets"""
 import logging

--- a/src/smclarify/util/dataset.py
+++ b/src/smclarify/util/dataset.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 """Convenience facility to access datasets"""
 import os

--- a/tests/integration/test_bias_metrics.py
+++ b/tests/integration/test_bias_metrics.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 import logging

--- a/tests/unit/bias/metrics/test_metrics.py
+++ b/tests/unit/bias/metrics/test_metrics.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 from smclarify.bias.metrics import AD, CDDL, CI, DAR, DCA, DCR, DI, DPL, DRR, FT, JS, KL, LP, RD, TE, KS, SD, GE
 from smclarify.bias.metrics import metric_one_vs_all

--- a/tests/unit/bias/metrics/test_registry.py
+++ b/tests/unit/bias/metrics/test_registry.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 import pytest
 from smclarify.bias.metrics import registry

--- a/tests/unit/bias/test_report.py
+++ b/tests/unit/bias/test_report.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 from typing import NamedTuple, List, Any, Union, Dict
 
 import pandas as pd

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
-# Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+# SPDX-License-Identifier: Apache-2.0
 
 from smclarify.util import pdf, pdfs_aligned_nonzero
 import numpy as np


### PR DESCRIPTION
*Issue #, if available:* https://tiny.amazon.com/mlnzhub5

*Description of changes:*
- Update LICENSE file and file headers to Apache 2.0 license.

License text taken from: https://www.apache.org/licenses/LICENSE-2.0
File headers taken from: https://tiny.amazon.com/w936idr1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
