### PR TITLE
manually add workflow approval

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,36 @@ name: Python package
 on: [push, pull_request]
 
 jobs:
+  collab-check:
+    runs-on: ubuntu-latest
+    outputs:
+      approval-env: ${{ steps.collab-check.outputs.result }}
+    steps:
+      - name: Collaborator Check
+        uses: actions/github-script@v7
+        id: collab-check
+        with:
+          github-token: ${{ github.token }}
+          result-encoding: string
+          script: |
+            try {
+              const res = await github.rest.repos.checkCollaborator({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: "${{ github.event.pull_request.user.login }}",
+              });
+              console.log("Verifed ${{ github.event.pull_request.user.login }} is a repo collaborator. Auto Approving PR Checks.")
+              return res.status == "204" ? "auto-approve" : "manual-approval"
+            } catch (error) {
+              console.log("${{ github.event.pull_request.user.login }} is not a collaborator. Requiring Manual Approval to run PR Checks.")
+              return "manual-approval"
+            }
+  wait-for-approval:
+    runs-on: ubuntu-latest
+    needs: [collab-check]
+    environment: ${{ needs.collab-check.outputs.approval-env }}
+    steps:
+      - run: echo "Workflow Approved! Starting PR Checks."
   test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
*Issue #, 

*Description of changes:
Ensure that your GitHub workflows cannot be automatically triggered when a non-contributor submits a pull request or using similar event. Especially if you have workflows that run integration tests, please ensure a [manual approval](https://github.com/aws/sagemaker-python-sdk/blob/master/.github/workflows/codebuild-ci.yml#L39) step is added before triggering the workflow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
